### PR TITLE
Fixes

### DIFF
--- a/etc/justfile
+++ b/etc/justfile
@@ -49,8 +49,9 @@ setup-gaming:
   flatpak override --user --env=OBS_VKCAPTURE=1 com.valvesoftware.Steam
 
 setup-just:
-  echo 'Copying over justfile from /etc/justfile ...'
+  echo 'Backing up current justfile to ~/.justfile-bak ...'
   mv ~/.justfile ~/.justfile-bak
+  echo 'Copying over justfile from /etc/justfile ...'
   cp /etc/justfile ~/.justfile
 
 nix-me-up:

--- a/etc/justfile
+++ b/etc/justfile
@@ -36,7 +36,7 @@ setup-gaming:
   echo 'Setting up gaming experience ... lock and load.'
   flatpak install -y --user \\
   com.discordapp.Discord \\
-  org.freedesktop.Platform.GStreamer.gstreamer-vaapi \\
+  org.freedesktop.Platform.GStreamer.gstreamer-vaapi//22.08 \\
   org.freedesktop.Platform.VulkanLayer.MangoHud//22.08 \\
   org.freedesktop.Platform.VulkanLayer.OBSVkCapture//22.08 \\
   org.freedesktop.Platform.VulkanLayer.vkBasalt//22.08 \\

--- a/etc/justfile
+++ b/etc/justfile
@@ -48,6 +48,11 @@ setup-gaming:
   flatpak override --user --env=MANGOHUD=1 com.valvesoftware.Steam
   flatpak override --user --env=OBS_VKCAPTURE=1 com.valvesoftware.Steam
 
+setup-just:
+  echo 'Copying over justfile from /etc/justfile ...'
+  mv ~/.justfile ~/.justfile-bak
+  cp /etc/justfile ~/.justfile
+
 nix-me-up:
   echo 'Setting phasers to kill. Installing nix.'
   /usr/bin/ublue-nix-install

--- a/etc/yafti.yml
+++ b/etc/yafti.yml
@@ -55,6 +55,7 @@ screens:
             - Image Viewer: org.gnome.Loupe
             - Logs: org.gnome.Logs
             - Maps: org.gnome.Maps
+            - Media Player: com.github.rafostar.Clapper
             - Text Editor: org.gnome.TextEditor
             - Weather: org.gnome.Weather
             - Web: org.gnome.Epiphany


### PR DESCRIPTION
- Adds Clapper to the Core apps selection, as 'Media Player'
- Specifies version for gstreamer-vaapi runtime extension, to match other extensions and keep the `just` command non-interactive