### PR TITLE
ISO generation

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,52 @@
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+name: release-please
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        with:
+          release-type: node
+          package-name: release-please-action
+
+  build-iso:
+    name: Generate and Release ISOs
+    runs-on: ubuntu-latest
+    needs: release-please
+    if: needs.release-please.outputs.releases_created
+    container:
+      image: fedora:38
+      options: --privileged
+    steps:
+      - uses: actions/checkout@v3
+      - name: Generate ISO
+        uses: ublue-os/isogenerator@main
+        id: isogenerator
+        with:
+          image-name: zeliblue
+          installer-repo: releases
+          installer-major-version: 38
+      - name: install github CLI
+        run: |
+          sudo dnf install 'dnf-command(config-manager)' -y
+          sudo dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
+          sudo dnf install gh -y
+      - name: Upload ISO
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run:
+          gh release upload ${{ needs.release-please.outputs.tag }} ${{ steps.isogenerator.outputs.iso-path }} -R ublue-os/main --clobber
+      - name: Upload SHA256SUM
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run:
+          gh release upload ${{ needs.release-please.outputs.tag }} ${{ steps.isogenerator.outputs.sha256sum-path }} -R ublue-os/main --clobber


### PR DESCRIPTION
Adds the release-please GitHub action, as well as the build-iso bits from [ublue's isogenerator repo](https://github.com/ublue-os/isogenerator). Also start using the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) styling for commit messages.