### PR TITLE
feat: Add custom dconf settings

### DIFF
--- a/usr/etc/dconf/db/local.d/01-zeliblue
+++ b/usr/etc/dconf/db/local.d/01-zeliblue
@@ -1,0 +1,23 @@
+[org/gnome/desktop/interface]
+clock-format='12h'
+clock-show-weekday=true
+font-antialiasing="rgba"
+gtk-theme="adw-gtk3"
+
+[org/gnome/desktop/wm/keybindings]
+move-to-workspace-1 = ['<Alt><Super>Home']
+move-to-workspace-last = ['<Alt><Super>End']
+move-to-workspace-left = ['<Alt><Super>Left']
+move-to-workspace-right = ['<Alt><Super>Right']
+switch-to-workspace-left = ['<Super>Left']
+switch-to-workspace-right = ['<Super>Right']
+
+[org/gnome/desktop/peripherals/touchpad]
+tap-to-click=true
+
+[org/gnome/mutter]
+center-new-windows=true
+
+[org/gnome/mutter/keybindings]
+toggle-tiled-left = ['<Control><Super>Left']
+toggle-tiled-right = ['<Control><Super>Right']

--- a/usr/etc/dconf/profile/user
+++ b/usr/etc/dconf/profile/user
@@ -1,0 +1,2 @@
+user-db:user
+system-db:local


### PR DESCRIPTION
Adjusts default keyboard shortcuts:
- The default workspace navigation keybindings in GNOME feel a bit out of place as of GNOME 40; PgUp and PgDown are still used there, but "up" and "down" don't make as much sense with the workspaces now being horizontal. Keybinds are changed to be more akin to what elementary OS uses, and to simplify workspace navigation.
- Window tiling keybinds were adjusted to accommodate the above changes.

Tweaks some UI components:
- Sets the default clock format to 12h instead of 24h
- Clock now shows the weekday
- Sets font antialiasing to rgba
- Default GTK theme set to adw-gtk3 for better visual consistency with libadwaita apps

Miscellaneous tweaks:
- Tap-to-click enabled by default for touchpads
- Newly-opened windows are centered, rather than the vanilla "smart" placement