### PR TITLE
feat: add keyboard shortcut to launch Console

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Notable changes include:
 
 **dconf settings**
 - Workspace navigation shortcuts are more akin to elementary OS's, to be more intuitive for horizontal workspaces
+- Super+t to launch Console, also à la elementary OS
 - Other miscellaneous tweaks
 
 ## Installation

--- a/usr/etc/dconf/db/local.d/01-zeliblue
+++ b/usr/etc/dconf/db/local.d/01-zeliblue
@@ -21,3 +21,11 @@ center-new-windows=true
 [org/gnome/mutter/keybindings]
 toggle-tiled-left = ['<Control><Super>Left']
 toggle-tiled-right = ['<Control><Super>Right']
+
+[org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0]
+binding='<Super>t'
+command='kgx'
+name="Launch Console"
+
+[org/gnome/settings-daemon/plugins/media-keys]
+custom-keybindings=['/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0/']


### PR DESCRIPTION
Adds Super+t as a keybinding to launch Console, à la elementary OS's default Terminal shortcut