### PR TITLE
feat!: Revamp Flathub setup

### DIFF
--- a/usr/share/ublue-os/firstboot/yafti.yml
+++ b/usr/share/ublue-os/firstboot/yafti.yml
@@ -12,11 +12,11 @@ screens:
   can-we-modify-your-flatpaks:
     source: yafti.screen.consent
     values:
-      title: Set Up Flathub
+      title: Prepare System
       condition:
         run: flatpak remotes --columns=name | grep fedora
       description: |
-        Set up Flathub. This is the source of apps installed in later steps, and the primary source of apps installed via Software.
+        Prepare system for app installation via the Software app.
       actions:
         - run: flatpak remote-delete --system --force fedora
         - run: flatpak remote-delete --user --force fedora
@@ -28,7 +28,7 @@ screens:
       condition:
         run: flatpak remotes --system --columns=name | grep flathub | wc -l | grep '^0$'
       description: |
-        Set up Flathub on the system.
+        Set up Flathub on the system. This is the source of core system apps installed in a later step, and can also be used to install more apps for every user on the system.
       actions:
         - run: flatpak remote-add --if-not-exists --system --title="Flathub (System)" flathub https://flathub.org/repo/flathub.flatpakrepo
   check-user-flathub:
@@ -38,7 +38,7 @@ screens:
       condition:
         run: flatpak remotes --user --columns=name | grep flathub | wc -l | grep '^0$'
       description: |
-        Set up Flathub for the current user.
+        Set up Flathub for the current user. Apps can be installed for the current user only, without affecting other users on the system.
       actions:
         - run: flatpak remote-add --if-not-exists --user flathub https://flathub.org/repo/flathub.flatpakrepo
   applications:

--- a/usr/share/ublue-os/firstboot/yafti.yml
+++ b/usr/share/ublue-os/firstboot/yafti.yml
@@ -26,21 +26,21 @@ screens:
     values:
       title: Missing Flathub Repository (System)
       condition:
-        run: flatpak remotes --system --columns=name | grep flathub | wc -l | grep '^0$'
+        run: flatpak remotes --system --columns=name | grep flathub-system | wc -l | grep '^0$'
       description: |
         Set up Flathub on the system. This is the source of core system apps installed in a later step, and can also be used to install more apps for every user on the system.
       actions:
-        - run: flatpak remote-add --if-not-exists --system --title="Flathub (System)" flathub https://flathub.org/repo/flathub.flatpakrepo
+        - run: flatpak remote-add --if-not-exists --system --title="Flathub (System)" flathub-system https://flathub.org/repo/flathub.flatpakrepo
   check-user-flathub:
     source: yafti.screen.consent
     values:
       title: Missing Flathub Repository (User)
       condition:
-        run: flatpak remotes --user --columns=name | grep flathub | wc -l | grep '^0$'
+        run: flatpak remotes --user --columns=name | grep flathub-user | wc -l | grep '^0$'
       description: |
         Set up Flathub for the current user. Apps can be installed for the current user only, without affecting other users on the system.
       actions:
-        - run: flatpak remote-add --if-not-exists --user flathub https://flathub.org/repo/flathub.flatpakrepo
+        - run: flatpak remote-add --if-not-exists --user flathub-user https://flathub.org/repo/flathub.flatpakrepo
   applications:
     source: yafti.screen.package
     values:

--- a/usr/share/ublue-os/firstboot/yafti.yml
+++ b/usr/share/ublue-os/firstboot/yafti.yml
@@ -33,8 +33,7 @@ screens:
       description: |
         Set up Flathub on the system.
       actions:
-        - run: flatpak remote-add --if-not-exists --system flathub https://flathub.org/repo/flathub.flatpakrepo
-        - run: flatpak remote-modify --system flathub --no-filter --title="Flathub (System)"
+        - run: flatpak remote-add --if-not-exists --system --title="Flathub (System)" flathub https://flathub.org/repo/flathub.flatpakrepo
   check-user-flathub:
     source: yafti.screen.consent
     values:

--- a/usr/share/ublue-os/firstboot/yafti.yml
+++ b/usr/share/ublue-os/firstboot/yafti.yml
@@ -21,9 +21,6 @@ screens:
         - run: flatpak remote-delete --system --force fedora
         - run: flatpak remote-delete --user --force fedora
         - run: flatpak remove --system --noninteractive --all
-        - run: flatpak remote-add --if-not-exists --system flathub https://flathub.org/repo/flathub.flatpakrepo
-        - run: flatpak remote-modify --system flathub --no-filter --title="Flathub (System)"
-        - run: flatpak remote-add --if-not-exists --user flathub https://flathub.org/repo/flathub.flatpakrepo
   check-system-flathub:
     source: yafti.screen.consent
     values:

--- a/usr/share/ublue-os/firstboot/yafti.yml
+++ b/usr/share/ublue-os/firstboot/yafti.yml
@@ -24,21 +24,21 @@ screens:
   check-system-flathub:
     source: yafti.screen.consent
     values:
-      title: Missing Flathub Repository (System)
+      title: Add Flathub (System)
       condition:
         run: flatpak remotes --system --columns=name | grep flathub-system | wc -l | grep '^0$'
       description: |
-        Set up Flathub on the system. This is the source of core system apps installed in a later step, and can also be used to install more apps for every user on the system.
+        Add Flathub for the system. This is the source of core system apps installed in a later step, and it can also be used to install more apps for every user on the system.
       actions:
         - run: flatpak remote-add --if-not-exists --system --title="Flathub (System)" flathub-system https://flathub.org/repo/flathub.flatpakrepo
   check-user-flathub:
     source: yafti.screen.consent
     values:
-      title: Missing Flathub Repository (User)
+      title: Add Flathub (User)
       condition:
         run: flatpak remotes --user --columns=name | grep flathub-user | wc -l | grep '^0$'
       description: |
-        Set up Flathub for the current user. Apps can be installed for the current user only, without affecting other users on the system.
+        Add Flathub for the current user. This allows additional apps to be installed for the current user only, without affecting other users on the system.
       actions:
         - run: flatpak remote-add --if-not-exists --user flathub-user https://flathub.org/repo/flathub.flatpakrepo
   applications:

--- a/usr/share/ublue-os/just/custom.just
+++ b/usr/share/ublue-os/just/custom.just
@@ -4,7 +4,7 @@ setup-flatpaks:
   flatpaks=$(yq -- '.firstboot.flatpaks[]' "/usr/share/ublue-os/recipe.yml")
   for pkg in $flatpaks; do \
       echo "Installing: ${pkg}" && \
-      flatpak install --user --noninteractive flathub $pkg; \
+      flatpak install --noninteractive flathub-user $pkg; \
   done
 
 setup-gaming:


### PR DESCRIPTION
Breaking change because it involves changing the names of added Flatpak remotes, and so will conflict with existing Zeliblue installations.