### PR TITLE
refactor: Make more use of modules

### DIFF
--- a/config/common-bling.yml
+++ b/config/common-bling.yml
@@ -1,0 +1,10 @@
+type: bling # configure what to pull in from ublue-os/bling
+install:
+  # - fonts # selection of common good free fonts
+  - justfiles # add "!include /usr/share/ublue-os/just/bling.just"
+              # in your custom.just (added by default) or local justfile
+  # - nix-installer # shell shortcuts for determinate system's nix installers
+  - ublue-os-wallpapers
+  - ublue-update # https://github.com/ublue-os/ublue-update
+  - dconf-update-service # a service unit that updates the dconf db on boot
+  # - devpod # https://devpod.sh/ as an rpm

--- a/config/common-packages.yml
+++ b/config/common-packages.yml
@@ -1,0 +1,6 @@
+type: rpm-ostree
+install:
+ - fish
+remove:
+ - firefox
+ - firefox-langpacks

--- a/config/common-packages.yml
+++ b/config/common-packages.yml
@@ -1,6 +1,7 @@
 type: rpm-ostree
 install:
  - fish
+ - micro
 remove:
  - firefox
  - firefox-langpacks

--- a/config/common-scripts.yml
+++ b/config/common-scripts.yml
@@ -1,0 +1,6 @@
+type: script
+scripts:
+  - flatpak-setup.sh
+  - image-info.sh
+  # this sets up the proper policy & signing files for signed images to work
+  - signing.sh

--- a/config/common-services.yml
+++ b/config/common-services.yml
@@ -1,0 +1,7 @@
+type: systemd
+system:
+  enabled:
+    - zeliblue-flatpak-manager.service
+user:
+  enabled:
+    - zeliblue-user-setup.service

--- a/config/gnome-packages.yml
+++ b/config/gnome-packages.yml
@@ -1,0 +1,7 @@
+type: rpm-ostree
+install:
+ - gnome-console
+remove:
+ - gnome-classic-session
+ - gnome-terminal
+ - gnome-terminal-nautilus

--- a/config/zeliblue-deck.yml
+++ b/config/zeliblue-deck.yml
@@ -4,7 +4,7 @@ name: zeliblue-deck
 description: The zeliblue GNOME experience, but for Steam Deck
 
 # the base image to build on top of (FROM) and the version tag to use
-base-image: ghcr.io/zelikos/zeliblue
+base-image: ghcr.io/ublue-os/silverblue-main
 image-version: 38 # latest is also supported if you want new updates ASAP
 
 # list of modules, executed in order

--- a/config/zeliblue-deck.yml
+++ b/config/zeliblue-deck.yml
@@ -19,6 +19,7 @@ modules:
                   # read more in the files module's README
       - deck: /usr
 
+  - from-file: common-packages.yml
   - from-file: gnome-packages.yml
 
   - type: rpm-ostree
@@ -26,9 +27,6 @@ modules:
       # - https://copr.fedorainfracloud.org/coprs/atim/starship/repo/fedora-%OS_VERSION%/atim-starship-fedora-%OS_VERSION%.repo
       - https://copr.fedorainfracloud.org/coprs/kylegospo/bazzite/repo/fedora-38/kylegospo-bazzite-fedora-38.repo
     install:
-      # - micro
-      # - starship
-      - fish
       - gamescope
       - gamescope-session
       - mangohud

--- a/config/zeliblue-deck.yml
+++ b/config/zeliblue-deck.yml
@@ -11,8 +11,6 @@ image-version: 38 # latest is also supported if you want new updates ASAP
 # you can include multiple instances of the same module
 modules:
 
-  - from-file: gnome-packages.yml
-
   - type: files
     files:
       - usr: /usr # copy static configurations
@@ -20,6 +18,8 @@ modules:
                   # added into /usr/etc/ as that is the proper "distro" config directory on ostree
                   # read more in the files module's README
       - deck: /usr
+
+  - from-file: gnome-packages.yml
 
   - type: rpm-ostree
     repos:

--- a/config/zeliblue-deck.yml
+++ b/config/zeliblue-deck.yml
@@ -36,6 +36,8 @@ modules:
     remove:
       - mesa-va-drivers-freeworld
 
+  - from-file: common-services.yml
+
   - type: systemd
     system:
       enabled:

--- a/config/zeliblue-deck.yml
+++ b/config/zeliblue-deck.yml
@@ -36,6 +36,8 @@ modules:
     remove:
       - mesa-va-drivers-freeworld
 
+  - from-file: common-bling.yml
+
   - from-file: common-services.yml
 
   - type: systemd

--- a/config/zeliblue-deck.yml
+++ b/config/zeliblue-deck.yml
@@ -11,6 +11,8 @@ image-version: 38 # latest is also supported if you want new updates ASAP
 # you can include multiple instances of the same module
 modules:
 
+  - from-file: gnome-packages.yml
+
   - type: files
     files:
       - usr: /usr # copy static configurations
@@ -26,6 +28,7 @@ modules:
     install:
       # - micro
       # - starship
+      - fish
       - gamescope
       - gamescope-session
       - mangohud
@@ -37,11 +40,11 @@ modules:
 
   - type: systemd
     system:
-      disabled:
-        - gdm.service
       enabled:
         - zelideck-autologin.service
         - sddm.service
+      disabled:
+        - gdm.service
 
   # - type: yafti # if included, yafti and it's dependencies (pip & libadwaita)
   #               #  will be installed and set up
@@ -52,6 +55,6 @@ modules:
   - type: script
     scripts:
       - image-info.sh
-      - steamos-setup.sh
+      # - steamos-setup.sh
       # this sets up the proper policy & signing files for signed images to work
       - signing.sh

--- a/config/zeliblue-deck.yml
+++ b/config/zeliblue-deck.yml
@@ -50,9 +50,8 @@ modules:
 
   - type: yafti
 
+  - from-file: common-scripts.yml
+
   - type: script
     scripts:
-      - image-info.sh
-      # - steamos-setup.sh
-      # this sets up the proper policy & signing files for signed images to work
-      - signing.sh
+      - steamos-setup.sh

--- a/config/zeliblue-deck.yml
+++ b/config/zeliblue-deck.yml
@@ -44,11 +44,7 @@ modules:
       disabled:
         - gdm.service
 
-  # - type: yafti # if included, yafti and it's dependencies (pip & libadwaita)
-  #               #  will be installed and set up
-  #   custom-flatpaks: # this section is optional
-  #     # - Celluloid: io.github.celluloid_player.Celluloid
-  #     # - Krita: org.kde.krita
+  - type: yafti
 
   - type: script
     scripts:

--- a/config/zeliblue.yml
+++ b/config/zeliblue.yml
@@ -27,9 +27,4 @@ modules:
 
   - type: yafti
 
-  - type: script
-    scripts:
-      - flatpak-setup.sh
-      - image-info.sh
-      # this sets up the proper policy & signing files for signed images to work
-      - signing.sh
+  - from-file: common-scripts.yml

--- a/config/zeliblue.yml
+++ b/config/zeliblue.yml
@@ -21,24 +21,7 @@ modules:
   - from-file: common-packages.yml
   - from-file: gnome-packages.yml
 
-  - type: bling # configure what to pull in from ublue-os/bling
-    install:
-      # - fonts # selection of common good free fonts
-      - justfiles # add "!include /usr/share/ublue-os/just/bling.just"
-                  # in your custom.just (added by default) or local justfile
-      # - nix-installer # shell shortcuts for determinate system's nix installers
-      - ublue-os-wallpapers
-      - ublue-update # https://github.com/ublue-os/ublue-update
-      - dconf-update-service # a service unit that updates the dconf db on boot
-      # - devpod # https://devpod.sh/ as an rpm
-
-  - type: systemd
-    system:
-      enabled:
-        - zeliblue-flatpak-manager.service
-    user:
-      enabled:
-        - zeliblue-user-setup.service
+  - from-file: common-services.yml
 
   - type: yafti
 

--- a/config/zeliblue.yml
+++ b/config/zeliblue.yml
@@ -11,14 +11,14 @@ image-version: latest # latest is also supported if you want new updates ASAP
 # you can include multiple instances of the same module
 modules:
 
-  - from-file: gnome-packages.yml
-
   - type: files
     files:
       - usr: /usr # copy static configurations
                   # configuration you wish to end up in /etc/ on the booted system should be
                   # added into /usr/etc/ as that is the proper "distro" config directory on ostree
                   # read more in the files module's README
+
+  - from-file: gnome-packages.yml
 
   - type: rpm-ostree
     repos:

--- a/config/zeliblue.yml
+++ b/config/zeliblue.yml
@@ -18,13 +18,17 @@ modules:
                   # added into /usr/etc/ as that is the proper "distro" config directory on ostree
                   # read more in the files module's README
 
+  # rpm-ostree
   - from-file: common-packages.yml
   - from-file: gnome-packages.yml
 
+  # uBlue bling
   - from-file: common-bling.yml
 
+  # systemd services
   - from-file: common-services.yml
 
   - type: yafti
 
+  # Setup scripts, etc
   - from-file: common-scripts.yml

--- a/config/zeliblue.yml
+++ b/config/zeliblue.yml
@@ -18,18 +18,8 @@ modules:
                   # added into /usr/etc/ as that is the proper "distro" config directory on ostree
                   # read more in the files module's README
 
+  - from-file: common-packages.yml
   - from-file: gnome-packages.yml
-
-  - type: rpm-ostree
-    repos:
-      # - https://copr.fedorainfracloud.org/coprs/atim/starship/repo/fedora-%OS_VERSION%/atim-starship-fedora-%OS_VERSION%.repo
-    install:
-      # - micro
-      # - starship
-      - fish
-    remove:
-      - firefox # default firefox removed in favor of flatpak
-      - firefox-langpacks # langpacks needs to also be removed to prevent dependency problems
 
   - type: bling # configure what to pull in from ublue-os/bling
     install:

--- a/config/zeliblue.yml
+++ b/config/zeliblue.yml
@@ -27,7 +27,6 @@ modules:
       # - micro
       # - starship
       - fish
-      - gnome-console
     remove:
       - firefox # default firefox removed in favor of flatpak
       - firefox-langpacks # langpacks needs to also be removed to prevent dependency problems

--- a/config/zeliblue.yml
+++ b/config/zeliblue.yml
@@ -21,6 +21,8 @@ modules:
   - from-file: common-packages.yml
   - from-file: gnome-packages.yml
 
+  - from-file: common-bling.yml
+
   - from-file: common-services.yml
 
   - type: yafti

--- a/config/zeliblue.yml
+++ b/config/zeliblue.yml
@@ -11,6 +11,8 @@ image-version: latest # latest is also supported if you want new updates ASAP
 # you can include multiple instances of the same module
 modules:
 
+  - from-file: gnome-packages.yml
+
   - type: files
     files:
       - usr: /usr # copy static configurations
@@ -29,9 +31,6 @@ modules:
     remove:
       - firefox # default firefox removed in favor of flatpak
       - firefox-langpacks # langpacks needs to also be removed to prevent dependency problems
-      - gnome-classic-session
-      - gnome-terminal
-      - gnome-terminal-nautilus
 
   - type: bling # configure what to pull in from ublue-os/bling
     install:

--- a/config/zeliblue.yml
+++ b/config/zeliblue.yml
@@ -40,8 +40,7 @@ modules:
       enabled:
         - zeliblue-user-setup.service
 
-  - type: yafti # if included, yafti and it's dependencies (pip & libadwaita)
-                #  will be installed and set up
+  - type: yafti
 
   - type: script
     scripts:


### PR DESCRIPTION
Moves common packages and configurations into `from-file` modules.

Now building zeliblue-deck from silverblue-main instead of from zeliblue, making use of the new modules.

This will also make supporting a kinoite image---and possibly other derivatives---simpler in the future.