### PR TITLE
ci: Configure pull action

### DIFF
--- a/.github/pull.yml
+++ b/.github/pull.yml
@@ -1,7 +1,5 @@
 version: "1"
 rules:
-  - base: template
-    upstream: ublue-os:template    # change `wei` to the owner of upstream repo
-    # mergeMethod: hardreset
   - base: live
-    upstream: zelikos:template
+    upstream: ublue-os:template
+    mergeMethod: squash

--- a/.github/pull.yml
+++ b/.github/pull.yml
@@ -2,4 +2,4 @@ version: "1"
 rules:
   - base: live
     upstream: ublue-os:template
-    mergeMethod: squash
+    mergeMethod: merge


### PR DESCRIPTION
Also simplifying merging in changes from upstream, i.e. instead of syncing this repo's template branch first *then* merging template into live as I've been doing manually, we just merge from upstream template into live.