### PR TITLE
feat: Notify for initial flatpak setup

### DIFF
--- a/config/files/usr/bin/zeliblue-flatpak-manager
+++ b/config/files/usr/bin/zeliblue-flatpak-manager
@@ -13,6 +13,8 @@ if [[ -f $VER_FILE && $VER = $VER_RAN ]]; then
   exit 0
 fi
 
+/usr/bin/notify-send --app-name="Initial Setup" --urgency=normal --icon=applications-system-symbolic "Finalizing system setup. Please wait."
+
 # Opt out of and remove Fedora's flatpak repo
 if grep -qz 'fedora' <<< $(flatpak remotes); then
   /usr/lib/fedora-third-party/fedora-third-party-opt-out

--- a/config/files/usr/bin/zeliblue-flatpak-manager
+++ b/config/files/usr/bin/zeliblue-flatpak-manager
@@ -3,7 +3,7 @@
 # Adapted from uBlue's Bazzite (https://github.com/ublue-os/bazzite/blob/main/system_files/desktop/shared/usr/bin/bazzite-flatpak-manager)
 
 # Script Version
-VER=2
+VER=3
 VER_FILE="/etc/zeliblue/flatpak_manager_version"
 VER_RAN=$(cat $VER_FILE)
 

--- a/config/files/usr/bin/zeliblue-flatpak-manager
+++ b/config/files/usr/bin/zeliblue-flatpak-manager
@@ -48,5 +48,7 @@ if [[ -n $REMOVE_LIST ]]; then
   done
 fi
 
+/usr/bin/notify-send --app-name="Initial Setup" --urgency=normal --icon=applications-system-symbolic "Setup complete. Your system is ready to go!"
+
 mkdir -p /etc/zeliblue
 echo $VER > $VER_FILE


### PR DESCRIPTION
Add notifications at the beginning and end of zeliblue-flatpak-manager, so users are notified that the initial setup process is going on.