### PR TITLE
fix: Revert to -user and -system for flathub remotes

### DIFF
--- a/config/files/usr/etc/dconf/db/local.d/01-zeliblue
+++ b/config/files/usr/etc/dconf/db/local.d/01-zeliblue
@@ -43,7 +43,7 @@ name="Launch Console"
 custom-keybindings=['/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0/']
 
 [org/gnome/software]
-packaging-format-preference=['flatpak:flathub']
+packaging-format-preference=['flatpak:flathub-user']
 download-updates=false
 download-updates-notify=false
 

--- a/modules/flatpaks/files/bin/system-flatpak-setup
+++ b/modules/flatpaks/files/bin/system-flatpak-setup
@@ -19,10 +19,7 @@ if grep -qz 'fedora' <<< $(flatpak remotes); then
 fi
 
 # Set up system Flathub if not already installed
-flatpak remote-add --if-not-exists --system flathub https://flathub.org/repo/flathub.flatpakrepo
-
-# In case fedora flatpak repo is already removed, but Flathub was left disabled by mistake
-flatpak remote-modify flathub --enable --system --title="Flathub (System)"
+flatpak remote-add --if-not-exists --system flathub-system --title="Flathub (System)" https://flathub.org/repo/flathub.flatpakrepo
 
 # Lists of flatpaks
 FLATPAK_LIST=$(flatpak list --columns=application)
@@ -33,7 +30,7 @@ REMOVE_LIST=$(cat /etc/flatpak/system-remove)
 if [[ -n $INSTALL_LIST ]]; then
   for flatpak in $INSTALL_LIST; do
     if grep -qvz $flatpak <<< $FLATPAK_LIST; then
-      flatpak install --system --noninteractive flathub $flatpak
+      flatpak install --system --noninteractive flathub-system $flatpak
     fi
   done
 fi

--- a/modules/flatpaks/files/bin/user-flatpak-setup
+++ b/modules/flatpaks/files/bin/user-flatpak-setup
@@ -15,7 +15,7 @@ fi
 if grep -qz 'fedora' <<< $(flatpak remotes); then
   flatpak remote-delete --user fedora --force
 fi
-flatpak remote-add --if-not-exists --user flathub https://flathub.org/repo/flathub.flatpakrepo
+flatpak remote-add --if-not-exists --user flathub-user https://flathub.org/repo/flathub.flatpakrepo
 
 # Lists of flatpaks
 FLATPAK_LIST=$(flatpak list --columns=application)
@@ -26,7 +26,7 @@ REMOVE_LIST=$(cat /etc/flatpak/user-remove)
 if [[ -n $INSTALL_LIST ]]; then
   for flatpak in $INSTALL_LIST; do
     if grep -qvz $flatpak <<< $FLATPAK_LIST; then
-      flatpak install --user --noninteractive flathub $flatpak
+      flatpak install --user --noninteractive flathub-user $flatpak
     fi
   done
 fi


### PR DESCRIPTION
You can't tell GNOME Software to prioritize a user remote vs a system remote if they have the same name, so I'm reverting to giving system flathub and user flathub altered remote names.