### PR TITLE
fix: Don't remove Flatpak lists before creating

### DIFF
--- a/modules/flatpaks/flatpaks.sh
+++ b/modules/flatpaks/flatpaks.sh
@@ -51,7 +51,7 @@ EOF
 
 echo "Creating system Flatpak install list"
 if [[ ${#SYSTEM_INSTALL[@]} -gt 0 ]]; then
-    rm -f $SYS_INSTALL_LIST && touch $SYS_INSTALL_LIST
+    touch $SYS_INSTALL_LIST
     for flatpak in "${SYSTEM_INSTALL[@]}"; do
         echo "Adding to system flatpak installs: $(printf ${flatpak})"
         echo $flatpak >> $SYS_INSTALL_LIST
@@ -60,7 +60,7 @@ fi
 
 echo "Creating system Flatpak removals list"
 if [[ ${#SYSTEM_REMOVE[@]} -gt 0 ]]; then
-    rm -f $SYS_REMOVE_LIST && touch $SYS_REMOVE_LIST
+    touch $SYS_REMOVE_LIST
     for flatpak in "${SYSTEM_REMOVE[@]}"; do
         echo "Adding to system flatpak removals: $(printf ${flatpak})"
         echo $flatpak >> $SYS_REMOVE_LIST
@@ -69,7 +69,7 @@ fi
 
 echo "Creating user Flatpak install list"
 if [[ ${#USER_INSTALL[@]} -gt 0 ]]; then
-    rm -f $USER_INSTALL_LIST && touch $USER_INSTALL_LIST
+    touch $USER_INSTALL_LIST
     for flatpak in "${USER_INSTALL[@]}"; do
         echo "Adding to user flatpak installs: $(printf ${flatpak})"
         echo $flatpak >> $USER_INSTALL_LIST
@@ -78,7 +78,7 @@ fi
 
 echo "Creating user Flatpak removals list"
 if [[ ${#USER_REMOVE[@]} -gt 0 ]]; then
-    rm -f $USER_REMOVE_LIST && touch $USER_REMOVE_LIST
+    touch $USER_REMOVE_LIST
     for flatpak in "${USER_REMOVE[@]}"; do
         echo "Adding to user flatpak removals: $(printf ${flatpak})"
         echo $flatpak >> $USER_REMOVE_LIST


### PR DESCRIPTION
There won't be anything to remove unless the module is called more than once, and if it's called more than once, the user would expect every Flatpak to be in the respective lists, so there's no need to call rm -f on it.