### PR TITLE
feat: Remove gnome-tweaks and gnome-software-rpm-ostree

### DIFF
--- a/config/gnome-packages.yml
+++ b/config/gnome-packages.yml
@@ -5,8 +5,10 @@ modules:
   - gnome-console
   remove:
   - gnome-classic-session
+  - gnome-software-rpm-ostree
   - gnome-terminal
   - gnome-terminal-nautilus
+  - gnome-tweaks
 
 - type: flatpaks
   system:


### PR DESCRIPTION
- The latter is unnecessary since system updates are handled by ublue-update. Plus, in my opinion, GNOME Software should instead be focused on the apps anyway, i.e. flatpak.

- I never use the former anymore