### PR TITLE
refactor: Remove flathub url from gnome- and plasma-packages

### DIFF
--- a/config/gnome-packages.yml
+++ b/config/gnome-packages.yml
@@ -12,7 +12,6 @@ modules:
 
 - type: flatpaks
   system:
-    repo-url: https://dl.flathub.org/repo/flathub.flatpakrepo
     repo-name: flathub-system
     repo-title: "Flathub (system-wide)"
     install:

--- a/config/plasma-packages.yml
+++ b/config/plasma-packages.yml
@@ -17,7 +17,6 @@ modules:
 
 - type: flatpaks
   system:
-    repo-url: https://dl.flathub.org/repo/flathub.flatpakrepo
     repo-name: flathub-system
     repo-title: "Flathub (system-wide)"
     install:
@@ -36,5 +35,4 @@ modules:
     - com.github.tchx84.Flatseal
     - org.gnome.Logs
   user:
-    repo-url: https://dl.flathub.org/repo/flathub.flatpakrepo
     repo-name: flathub-user


### PR DESCRIPTION
No longer needs to be specified