### PR TITLE
feat: Set fish as default shell in GNOME Console

### DIFF
--- a/config/files/silverblue/etc/dconf/db/local.d/01-zeliblue
+++ b/config/files/silverblue/etc/dconf/db/local.d/01-zeliblue
@@ -1,6 +1,9 @@
 [org/gnome/shell]
 favorite-apps = ['org.gnome.Nautilus.desktop', 'org.gnome.Epiphany.desktop', 'org.gnome.Calendar.desktop', 'org.gnome.World.PikaBackup.desktop', 'org.gnome.Software.desktop', 'org.gnome.Settings.desktop']
 
+[org/gnome/console]
+shell = ['fish']
+
 [org/gnome/desktop/interface]
 clock-format='12h'
 clock-show-weekday=true


### PR DESCRIPTION
Fixes #80 

The gsettings value uses an array instead of a string, apparently?