### PR TITLE
feat: Add distrobox config file

### DIFF
--- a/config/files/shared/etc/distrobox/distrobox.conf
+++ b/config/files/shared/etc/distrobox/distrobox.conf
@@ -1,0 +1,2 @@
+container_always_pull="1"
+container_manager="podman"


### PR DESCRIPTION
The main benefit here is enabling `container_always_pull`, but this also opens the door for more custom configuration in the future