### PR TITLE
feat: Simplify homebrew setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ Enables Homebrew in bash, zsh, and fish.
 
 Installs some CLI utilities via Homebrew. The full list can be found in [the Brewfile](/config/files/shared/share/zeliblue/Brewfile).
 
+### setup-homebrew
+
+A shortcut that runs each of the above `brew` commands.
+
 ### setup-davincibox
 
 Sets up a [davincibox](https://github.com/zelikos/davincibox) container with distrobox. Optionally takes "refresh" as a parameter to rebuild the container with the latest version of davincibox.

--- a/config/files/shared/share/ublue-os/just/60-custom.just
+++ b/config/files/shared/share/ublue-os/just/60-custom.just
@@ -64,6 +64,13 @@ brew-utilities:
   fi
   brew bundle --file=$HOME/.local/share/zeliblue/Brewfile
 
+# Install Homebrew, configure shells, and install Zeliblue utilities
+setup-homebrew:
+  #!/usr/bin/env bash
+  just brew
+  just brew-shell
+  just brew-utilities
+
 # Setup DaVinciBox container
 setup-davincibox mode="":
   #!/usr/bin/env bash


### PR DESCRIPTION
Add a `setup-homebrew` `just` command that runs the existing `brew` commands. Leaves the existing commands separate.