### PR TITLE
chore: Don't use pull action for template -> live

### DIFF
--- a/.github/pull.yml
+++ b/.github/pull.yml
@@ -3,5 +3,3 @@ rules:
   - base: template
     upstream: ublue-os:template
     mergeMethod: hardreset
-  - base: live
-    upstream: template


### PR DESCRIPTION
With all the changes Zeliblue has, I have to do merges manually anyway, so automatic PRs for template onto live don't actually help.