### PR TITLE
build: Rebase onto Fedora 39

### DIFF
--- a/config/plasma-config.yml
+++ b/config/plasma-config.yml
@@ -13,10 +13,8 @@ modules:
       - filelight
       - kate
       - kate-plugins
-      - kcalc
       - kfind
       - kwrite
-      - okular
 
   - type: default-flatpaks
     system:

--- a/config/plasma-config.yml
+++ b/config/plasma-config.yml
@@ -11,12 +11,11 @@ modules:
       - ark
       - ark-libs
       - filelight
-      - gwenview
-      - gwenview-libs
       - kate
       - kate-plugins
       - kcalc
       - kfind
+      - kwrite
       - okular
 
   - type: default-flatpaks

--- a/config/zeliblue-kinoite.yml
+++ b/config/zeliblue-kinoite.yml
@@ -5,7 +5,7 @@ description: Zeliblue, with KDE Plasma
 
 # the base image to build on top of (FROM) and the version tag to use
 base-image: ghcr.io/ublue-os/kinoite-main
-image-version: latest # latest is also supported if you want new updates ASAP
+image-version: 39
 
 # module configuration, executed in order
 # you can include multiple instances of the same module

--- a/config/zeliblue.yml
+++ b/config/zeliblue.yml
@@ -5,7 +5,7 @@ description: Akzel's custom uBlue image, based on https://ublue.it/making-your-o
 
 # the base image to build on top of (FROM) and the version tag to use
 base-image: ghcr.io/ublue-os/silverblue-main
-image-version: latest # latest is also supported if you want new updates ASAP
+image-version: 39
 
 # list of modules, executed in order
 # you can include multiple instances of the same module


### PR DESCRIPTION
While Fedora 39 hasn't officially released quite yet, the blocker issues seem to be limited to ARM devices and fresh installs. Since uBlue doesn't (yet) have ARM support anyway, bumping Zeliblue to 39 a bit early shouldn't be problematic.

Switches both Zeliblue and Zeliblue Plasma from the `latest` tag to the `39` tag. This change already took place separately for ZeliDeck in #106.

Also updates the rpm-ostree remove list in Plasma:

gwenview, kcalc, and okular have been [removed](https://pagure.io/workstation-ostree-config/c/9995a5f61bbaff0744822056737adc894025a6de?branch=f39) from the upstream Kinoite image and so no longer need to be removed here.

Kwrite was added back into `kinoite-main`, so it has been added to the remove list in favor of the Flatpak.