### PR TITLE
feat: Add Zeliblue GTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Zeliblue features the GNOME desktop as the flagship experience. Notable changes 
 
 There are also some additional flavors of Zeliblue:
 
+Zeliblue GTS, which is nearly identical to the main image. The difference is that GTS follows the latest version of Fedora, minus one. In other words, when Zeliblue is on Fedora 39, GTS is on Fedora 38. While the main image should work well for most users, GTS is provided for those that desire extra stability.
+
 Zeliblue Plasma (zeliblue-kinoite) uses the Plasma desktop environment instead of GNOME. It replaces multiple apps that are layered into the upstream image with Flatpak equivalents, as well as using `fish` as the default shell in Konsole.
 
 Zeliblue Deck shares the same core as Zeliblue but with additional customizations to offer a SteamOS-like experience. It is functional but very experimental; it shouldn't *break* anything, but, if you're looking for a SteamOS alternative, I'd recommend using [uBlue's Bazzite](https://github.com/ublue-os/bazzite) instead.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ You can also rebase an existing Silverblue/Kinoite installation to the latest bu
   systemctl reboot
   ```
 
-After first boot, the first time that [ublue-update]() runs it will automatically rebase you onto the signed image.
+After first boot, the first of the system updater will automatically rebase you onto the signed image.
 
 ## `just` commands
 

--- a/boot_menu.yml
+++ b/boot_menu.yml
@@ -3,8 +3,10 @@ ublue_variants:
     ks: /kickstart/ublue-os.ks
     flavors:
       - label: zeliblue
-        info: GNOME
+        info: For the latest features
+      - label: zeliblue-gts
+        info: For those that need extra stability
       - label: zeliblue-kinoite
-        info: KDE Plasma
+        info: Zeliblue with the KDE Plasma Desktop
       - label: zeliblue-deck
         info: SteamOS-like Experience (EXPERIMENTAL)

--- a/boot_menu.yml
+++ b/boot_menu.yml
@@ -3,9 +3,9 @@ ublue_variants:
     ks: /kickstart/ublue-os.ks
     flavors:
       - label: zeliblue
-        info: For the latest features
+        info: The main Zeliblue experience
       - label: zeliblue-gts
-        info: For those that need extra stability
+        info: Zeliblue GTS, for extra stability
       - label: zeliblue-kinoite
         info: Zeliblue with the KDE Plasma Desktop
       - label: zeliblue-deck

--- a/config/zeliblue-gts.yml
+++ b/config/zeliblue-gts.yml
@@ -1,0 +1,15 @@
+# image will be published to ghcr.io/<user>/<name>
+name: zeliblue-gts
+# description will be included in the image's metadata
+description: Zeliblue GTS (Grand-Touring Support), for those needing extra stability
+
+# the base image to build on top of (FROM) and the version tag to use
+base-image: ghcr.io/ublue-os/silverblue-main
+image-version: gts
+
+# list of modules, executed in order
+# you can include multiple instances of the same module
+modules:
+
+  - from-file: common-config.yml
+  - from-file: gnome-config.yml

--- a/config/zeliblue.yml
+++ b/config/zeliblue.yml
@@ -1,7 +1,7 @@
 # image will be published to ghcr.io/<user>/<name>
 name: zeliblue
 # description will be included in the image's metadata
-description: Akzel's custom uBlue image, based on https://ublue.it/making-your-own/
+description: An opiniated GNOME desktop experience, based on Fedora Silverblue
 
 # the base image to build on top of (FROM) and the version tag to use
 base-image: ghcr.io/ublue-os/silverblue-main


### PR DESCRIPTION
Adds a zeliblue-gts recipe, to follow the latest Fedora n-1 version.