### PR TITLE
ci: Add zeliblue-gts to build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,7 @@ jobs:
         # Don't add module configuration files, you will get errors.
         recipe:
           - zeliblue.yml
+          - zeliblue-gts.yml
           - zeliblue-deck.yml
           - zeliblue-kinoite.yml
 # !!!


### PR DESCRIPTION
Adding a new recipe works a lot better when it actually gets built too