### PR TITLE
chore: Add zeliblue-testing.yml to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 cosign.key
+config/zeliblue-testing.yml


### PR DESCRIPTION
A recipe I'm using for local testing, but not one that needs committed to the repository.