### PR TITLE
fix(kinoite): Don't use `Requires=xdg-desktop-autostart.target`

### DIFF
--- a/config/files/kinoite/lib/systemd/user/zeliblue-kinoite-config.service
+++ b/config/files/kinoite/lib/systemd/user/zeliblue-kinoite-config.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Configure Zeliblue Plasma for current user
-Requires=xdg-desktop-autostart.target
+#Requires=xdg-desktop-autostart.target
 ConditionPathExists=!%h/.config/zeliblue/zeliblue-configured
 
 [Service]


### PR DESCRIPTION
Doing so seems to cause xdg-desktop-portal issues, which also occurred in the default-flatpaks module, Bazzite, and Bluefin.

Will need further testing to 1) see if the service still runs without that line, and 2) if not, see what we can do here instead.