### PR TITLE
feat(gnome): Add Decibels to default-flatpaks

### DIFF
--- a/config/gnome-config.yml
+++ b/config/gnome-config.yml
@@ -23,6 +23,7 @@ modules:
         - org.gnome.Characters
         - org.gnome.clocks
         - org.gnome.Contacts
+        - com.vixalien.decibels
         - org.gnome.baobab
         - org.gnome.SimpleScan
         - org.gnome.Evince


### PR DESCRIPTION
Adds Decibels to the default flatpaks for GNOME images.

See #87 