### PR TITLE
feat: Switch to Inter as default font

### DIFF
--- a/config/common-config.yml
+++ b/config/common-config.yml
@@ -11,8 +11,8 @@ modules:
 
   - type: fonts
     fonts:
-      - google-fonts:
-          - Inter
+      google-fonts:
+        - Inter
 
   - type: rpm-ostree
     install:

--- a/config/common-config.yml
+++ b/config/common-config.yml
@@ -9,6 +9,11 @@ modules:
                   # added into /usr/etc/ as that is the proper "distro" config directory on ostree
                   # read more in the files module's README
 
+  - type: fonts
+    fonts:
+      - google-fonts:
+          - Inter
+
   - type: rpm-ostree
     install:
       - fish

--- a/config/files/kinoite/etc/xdg/kdeglobals
+++ b/config/files/kinoite/etc/xdg/kdeglobals
@@ -1,2 +1,11 @@
 [Desktop Entry]
 DefaultProfile=Zeliblue.profile
+
+[General]
+font=Inter,10,-1,5,50,0,0,0,0,0
+menuFont=Inter,10,-1,5,50,0,0,0,0,0
+smallestReadableFont=Inter,8,-1,5,50,0,0,0,0,0
+toolbarFont=Inter,10,-1,5,50,0,0,0,0,0
+
+[WM]
+activeFont=Inter,10,-1,5,50,0,0,0,0,0

--- a/config/files/silverblue/etc/dconf/db/gdm.d/01-zeliblue
+++ b/config/files/silverblue/etc/dconf/db/gdm.d/01-zeliblue
@@ -1,2 +1,5 @@
 [org/gnome/desktop/peripherals/touchpad]
 tap-to-click=true
+
+[org/gnome/desktop/interface]
+font-name="Inter 11"

--- a/config/files/silverblue/etc/dconf/db/local.d/01-zeliblue
+++ b/config/files/silverblue/etc/dconf/db/local.d/01-zeliblue
@@ -8,6 +8,8 @@ shell = ['fish']
 clock-format='12h'
 clock-show-weekday=true
 font-antialiasing="rgba"
+font-name="Inter 11"
+document-font-name="Inter 11"
 gtk-theme="adw-gtk3"
 
 [org/gnome/desktop/wm/keybindings]


### PR DESCRIPTION
- Downloads Inter via the `fonts` module
- Sets Inter as default font for GNOME and Plasma

Closes #131 