### PR TITLE
feat: Use app centers for app updates, ublue-update for other

### DIFF
--- a/config/files/shared/etc/ublue-update.d/system/01-flatpak-system-update.sh
+++ b/config/files/shared/etc/ublue-update.d/system/01-flatpak-system-update.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+#/usr/bin/flatpak --system update -y --noninteractive

--- a/config/files/shared/etc/ublue-update.d/user/00-flatpak-user-update.sh
+++ b/config/files/shared/etc/ublue-update.d/user/00-flatpak-user-update.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+#/usr/bin/flatpak --user update -y --noninteractive

--- a/config/files/silverblue/etc/dconf/db/local.d/01-zeliblue
+++ b/config/files/silverblue/etc/dconf/db/local.d/01-zeliblue
@@ -50,9 +50,6 @@ custom-keybindings=['/org/gnome/settings-daemon/plugins/media-keys/custom-keybin
 
 [org/gnome/software]
 packaging-format-preference=['flatpak:flathub-user']
-allow-updates=false
-download-updates=false
-download-updates-notify=false
 
 [org/gtk/gtk4/settings/file-chooser]
 sort-directories-first=true

--- a/config/files/silverblue/etc/dconf/db/local.d/locks/01-zeliblue-lock
+++ b/config/files/silverblue/etc/dconf/db/local.d/locks/01-zeliblue-lock
@@ -1,4 +1,0 @@
-[org/gnome/software]
-allow-updates=false
-download-updates=false
-download-updates-notify=false


### PR DESCRIPTION
Reverts #101 and 77e1058ff0f4b41d2177619efb198a57a7528a4f

Still use ublue-update for Flatpak repairs/cleanups

~~Investigating doing this approach for KDE Discover as well~~ Discover already ships without the rpm-ostree plugin, so no extra configuration is needed from us here