### PR TITLE
feat: Switch to Hack as default monospace font

### DIFF
--- a/config/common-config.yml
+++ b/config/common-config.yml
@@ -19,6 +19,8 @@ modules:
 
   - type: fonts
     fonts:
+      nerd-fonts:
+        - Hack
       google-fonts:
         - Inter
 

--- a/config/files/kinoite/etc/xdg/kdeglobals
+++ b/config/files/kinoite/etc/xdg/kdeglobals
@@ -5,7 +5,7 @@ DefaultProfile=Zeliblue.profile
 font=Inter,10,-1,5,50,0,0,0,0,0
 menuFont=Inter,10,-1,5,50,0,0,0,0,0
 smallestReadableFont=Inter,8,-1,5,50,0,0,0,0,0
-toolbarFont=Inter,10,-1,5,50,0,0,0,0,0
+toolbarFont=Inter,9,-1,5,50,0,0,0,0,0
 
 [WM]
 activeFont=Inter,10,-1,5,50,0,0,0,0,0

--- a/config/files/kinoite/etc/xdg/kdeglobals
+++ b/config/files/kinoite/etc/xdg/kdeglobals
@@ -2,6 +2,7 @@
 DefaultProfile=Zeliblue.profile
 
 [General]
+fixed=Hack Nerd Font Mono,10,-1,5,50,0,0,0,0,0
 font=Inter,10,-1,5,50,0,0,0,0,0
 menuFont=Inter,10,-1,5,50,0,0,0,0,0
 smallestReadableFont=Inter,8,-1,5,50,0,0,0,0,0

--- a/config/files/silverblue/etc/dconf/db/local.d/01-zeliblue
+++ b/config/files/silverblue/etc/dconf/db/local.d/01-zeliblue
@@ -10,6 +10,7 @@ clock-show-weekday=true
 font-antialiasing="rgba"
 font-name="Inter 11"
 document-font-name="Inter 11"
+monospace-font-name="Hack Nerd Font Mono 10"
 gtk-theme="adw-gtk3"
 
 [org/gnome/desktop/wm/keybindings]


### PR DESCRIPTION
Installs the Hack Nerd Font via the `fonts` module, and sets it as the default monospace font in dconf and in `kdeglobals`.

Also fixes an incorrect font size in `kdeglobals`.

Resolves #137 