### PR TITLE
ci: Remove `pull` action

### DIFF
--- a/.github/pull.yml
+++ b/.github/pull.yml
@@ -1,5 +1,0 @@
-version: "1"
-rules:
-  - base: template
-    upstream: ublue-os:template
-    mergeMethod: hardreset


### PR DESCRIPTION
`pull` has automatically synced the template branch a grand total of...one time, out of the many other times it has instead left an open PR, meaning I have to go click 'Sync Fork' to avoid a merge commit. I already manually merge the changes from `template` into `live` myself anyway, so at this point, `pull` just ends up being a waste of time rather than a help