### PR TITLE
fix(just): Use `echo` on arguments in conditionals

### DIFF
--- a/config/files/shared/share/ublue-os/just/60-custom.just
+++ b/config/files/shared/share/ublue-os/just/60-custom.just
@@ -69,7 +69,7 @@ setup-homebrew:
 # Setup DaVinciBox container
 setup-davincibox mode="":
   #!/usr/bin/env bash
-  if [[ {{mode}} == "refresh" ]]; then
+  if [[ $(echo {{mode}}) == "refresh" ]]; then
     distrobox stop -Y davincibox
     distrobox rm -Y davincibox
   fi
@@ -80,7 +80,7 @@ setup-davincibox mode="":
 install-davinci installer="":
   #!/usr/bin/env bash
   just --unstable setup-davincibox
-  if [[ {{installer}} == "" ]]; then
+  if [[ $(echo {{installer}}) == "" ]]; then
     echo "Please re-run this command with the path to DaVinci Resolve's installer."
     echo "Example 1 (installer in current directory):"
     echo "just install-davinci DaVinci_Resolve_18.5.1_Linux.run"


### PR DESCRIPTION
Otherwise, the conditionals error out because they only receive whitespace instead of an empty string.

Fixes #142 