### PR TITLE
fix(just): Clarify need for absolute path in `install-davinci` examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,13 +77,9 @@ Sets up a [davincibox](https://github.com/zelikos/davincibox) container with dis
 
 Uses the `setup-davincibox` command, then installs DaVinci Resolve into davincibox, which also adds launchers to the app grid/menu for ease of use. DaVinci Resolve must be downloaded from [their website](https://www.blackmagicdesign.com/products/davinciresolve), and the installer passed to the command as a parameter.
 
-Example 1 (if installer is in current directory):
+Example: `just install-davinci /full/path/to/DaVinci_Resolve_18.5.1_Linux.run`
 
-`just install-davinci DaVinci_Resolve_18.5.1_Linux.run`
-
-Example 2 (if installer is in a different directory):
-
-`just install-davinci /path/to/DaVinci_Resolve_18.5.1_Linux.run`
+The full path to the installer is required, even if in the current directory.
 
 ### remove-davinci
 

--- a/config/files/shared/share/ublue-os/just/60-custom.just
+++ b/config/files/shared/share/ublue-os/just/60-custom.just
@@ -82,10 +82,9 @@ install-davinci installer="":
   just --unstable setup-davincibox
   if [[ {{installer}} == "" ]]; then
     echo "Please re-run this command with the path to DaVinci Resolve's installer."
-    echo "Example 1 (installer in current directory):"
-    echo "just install-davinci DaVinci_Resolve_18.5.1_Linux.run"
-    echo "Example 2 (installer in different directory):"
-    echo "just install-davinci /path/to/DaVinci_Resolve_18.5.1_Linux.run"
+    echo "The full path is needed, even if in the current directory."
+    echo "Example:"
+    echo "just install-davinci /full/path/to/DaVinci_Resolve_18.5.1_Linux.run"
   else
     distrobox enter davincibox -- setup-davinci {{installer}} distrobox
   fi


### PR DESCRIPTION
The working directory for `just` commands is the user's $HOME. Directing users to provide `just install-davinci` with the absolute path is probably the simplest solution