### PR TITLE
build: Disable zeliblue-deck builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,8 +41,8 @@ jobs:
         recipe:
           - zeliblue.yml
           - zeliblue-gts.yml
-          - zeliblue-deck.yml
           - zeliblue-kinoite.yml
+        #   - zeliblue-deck.yml
 # !!!
 
     steps:

--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ Zeliblue GTS, which is nearly identical to the main image. The difference is tha
 
 Zeliblue Plasma (zeliblue-kinoite) uses the Plasma desktop environment instead of GNOME. It replaces multiple apps that are layered into the upstream image with Flatpak equivalents, as well as using `fish` as the default shell in Konsole.
 
-Zeliblue Deck shares the same core as Zeliblue but with additional customizations to offer a SteamOS-like experience. It is functional but very experimental; it shouldn't *break* anything, but, if you're looking for a SteamOS alternative, I'd recommend using [uBlue's Bazzite](https://github.com/ublue-os/bazzite) instead.
-
 ## Installation
 
 I recommend looking into either the [main uBlue images](https://universal-blue.org/images/) or [making your own](https://universal-blue.org/tinker/make-your-own/), but, if you want to, here's how you can use Zelibue on your system:

--- a/boot_menu.yml
+++ b/boot_menu.yml
@@ -8,5 +8,3 @@ ublue_variants:
         info: Zeliblue GTS, for extra stability
       - label: zeliblue-kinoite
         info: Zeliblue with the KDE Plasma Desktop
-      - label: zeliblue-deck
-        info: SteamOS-like Experience (EXPERIMENTAL)


### PR DESCRIPTION
Keeps the recipe and config/files/deck stuff, but for the time being I'm disabling builds of Zeliblue Deck. There hasn't been a successful build in nearly a month due to issues with layering Steam (again); I don't have much motivation to look into fixing it again (i.e. with whatever Bazzite is doing) and at this point, if/when I get a Steam Deck myself, I'd probably just use Bazzite anyway.