### PR TITLE
build: Add zeliblue-cli toolbox

### DIFF
--- a/.github/workflows/build-zeliblue-cli.yml
+++ b/.github/workflows/build-zeliblue-cli.yml
@@ -1,0 +1,106 @@
+name: Build and Push Zeliblue CLI Image
+on:
+  schedule:
+    - cron: '20 22 * * *'  # 10:20pm everyday
+  pull_request:
+  merge_group:
+  workflow_dispatch:
+env:
+    IMAGE_NAME: zeliblue-cli
+    IMAGE_TAGS: latest
+    IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  push-ghcr:
+    name: Build and push image
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    strategy:
+      fail-fast: false
+    steps:
+      # Checkout push-to-registry action GitHub repository
+      - name: Checkout Push to Registry action
+        uses: actions/checkout@v4
+
+      - name: Verify Fedora toolbox
+        uses: EyeCantCU/cosign-action/verify@v0.2.2
+        with:
+          containers: fedora-toolbox:latest
+
+      # Build metadata
+      - name: Image Metadata
+        uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: |
+            ${{ env.IMAGE_NAME }}
+          labels: |
+            io.artifacthub.package.readme-url=https://raw.githubusercontent.com/ublue-os/boxkit/main/README.md
+
+      # Build image using Buildah action
+      - name: Build Image
+        id: build_image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          containerfiles: |
+            ./toolboxes/Containerfile.zeliblue-cli
+          image: ${{ env.IMAGE_NAME }}
+          tags: ${{ env.IMAGE_TAGS }}
+          labels: ${{ steps.meta.outputs.labels }}
+          oci: false
+
+      # Workaround bug where capital letters in your GitHub username make it impossible to push to GHCR.
+      # https://github.com/macbre/push-to-ghcr/issues/12
+      - name: Lowercase Registry
+        id: registry_case
+        uses: ASzc/change-string-case-action@v6
+        with:
+          string: ${{ env.IMAGE_REGISTRY }}
+
+      # Push the image to GHCR (Image Registry)
+      - name: Push To GHCR
+        uses: redhat-actions/push-to-registry@v2
+        if: github.event_name != 'pull_request'
+        id: push
+        env:
+          REGISTRY_USER: ${{ github.actor }}
+          REGISTRY_PASSWORD: ${{ github.token }}
+        with:
+          image: ${{ steps.build_image.outputs.image }}
+          tags: ${{ steps.build_image.outputs.tags }}
+          registry: ${{ steps.registry_case.outputs.lowercase }}
+          username: ${{ env.REGISTRY_USER }}
+          password: ${{ env.REGISTRY_PASSWORD }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        if: github.event_name != 'pull_request'
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Sign container
+      - uses: sigstore/cosign-installer@v3.4.0
+        if: github.event_name != 'pull_request'
+
+      - name: Sign container image
+        if: github.event_name != 'pull_request'
+        run: |
+          echo "${{ env.COSIGN_PRIVATE_KEY }}" > cosign.key
+          wc -c cosign.key
+          cosign sign -y --key cosign.key ${{ steps.registry_case.outputs.lowercase }}/${{ env.IMAGE_NAME }}@${TAGS}
+        env:
+          TAGS: ${{ steps.push.outputs.digest }}
+          COSIGN_EXPERIMENTAL: false
+          COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
+
+      - name: Echo outputs
+        run: |
+          echo "${{ toJSON(steps.push.outputs) }}"

--- a/toolboxes/Containerfile.zeliblue-cli
+++ b/toolboxes/Containerfile.zeliblue-cli
@@ -6,6 +6,8 @@ LABEL com.github.containers.toolbox="true" \
 
 COPY ./toolboxes/packages.zeliblue-cli /toolbox-packages
 
+RUN cat toolbox-packages
+
 RUN dnf -y upgrade && \
     dnf -y install &(<toolbox-packages) && \
     dnf clean all

--- a/toolboxes/Containerfile.zeliblue-cli
+++ b/toolboxes/Containerfile.zeliblue-cli
@@ -6,10 +6,8 @@ LABEL com.github.containers.toolbox="true" \
 
 COPY ./toolboxes/packages.zeliblue-cli /toolbox-packages
 
-RUN cat toolbox-packages
-
 RUN dnf -y upgrade && \
-    dnf -y install &(<toolbox-packages) && \
+    dnf -y install $(<toolbox-packages) && \
     dnf clean all
 
 RUN rm /toolbox-packages

--- a/toolboxes/Containerfile.zeliblue-cli
+++ b/toolboxes/Containerfile.zeliblue-cli
@@ -1,0 +1,13 @@
+FROM ghcr.io/ublue-os/fedora-toolbox:latest
+
+LABEL com.github.containers.toolbox="true" \
+      usage="This image is meant to be used with the toolbox or distrobox command" \
+      summary="A cloud-native terminal experience for Zeliblue, powered by Fedora"
+
+COPY ./toolboxes/packages.zeliblue-cli /toolbox-packages
+
+RUN dnf -y upgrade && \
+    dnf -y install &(<toolbox-packages) && \
+    dnf clean all
+
+RUN rm /toolbox-packages

--- a/toolboxes/packages.zeliblue-cli
+++ b/toolboxes/packages.zeliblue-cli
@@ -1,0 +1,10 @@
+bat
+btop
+eza
+fastfetch
+fish
+git
+micro
+navi
+ripgrep
+zoxide


### PR DESCRIPTION
Use [uBlue's fedora toolbox image](https://github.com/ublue-os/toolboxes) as a basis for a `zeliblue-cli` toolbox image

Related to #148