### PR TITLE
feat(cli): Add chezmoi

### DIFF
--- a/toolboxes/Containerfile.zeliblue-cli
+++ b/toolboxes/Containerfile.zeliblue-cli
@@ -18,3 +18,6 @@ RUN curl -Lo /tmp/starship.tar.gz "https://github.com/starship/starship/releases
     tar -xzf /tmp/starship.tar.gz -C /tmp && \
     install -c -m 0755 /tmp/starship /usr/bin && \
     rm /tmp/*
+
+# Chezmoi
+RUN sh -c "$(curl -fsLS get.chezmoi.io)" -- -b /usr/bin


### PR DESCRIPTION
Installs `chezmoi` into the `zeliblue-cli` container for dotfile management.