### PR TITLE
feat(just): Make `zeliblue-cli` a toggle

### DIFF
--- a/config/files/shared/share/ublue-os/just/60-custom.just
+++ b/config/files/shared/share/ublue-os/just/60-custom.just
@@ -32,7 +32,31 @@ remove-davinci:
   distrobox stop -Y davincibox
   distrobox rm -Y davincibox
 
-
+# Toggle Zeliblue-CLI
+zeliblue-cli ACTION="prompt":
+    #!/usr/bin/bash
+    source /usr/lib/ujust/ujust.sh
+    CURRENT_STATE="Disabled"
+    if systemctl --quiet --user is-active zeliblue-cli.service; then
+      CURRENT_STATE="Enabled"
+    fi
+    OPTION={{ ACTION }}
+    if [ "$OPTION" == "prompt" ]; then
+      echo "Zeliblue CLI is currently: ${bold}${CURRENT_STATE}${normal}"
+      echo "Enable or Disable Zeliblue CLI?"
+      OPTION=$(ugum choose Enable Disable)
+    elif [ "$OPTION" == "help" ]; then
+      echo "Usage: ujust zeliblue-cli <option>"
+      echo "  <option>: Specify the quick option - 'enable' or 'disable'"
+      echo "  Use 'enable' to Enable Zeliblue CLI."
+      echo "  Use 'disable' to Disable Zeliblue CLI."
+      exit 0
+    fi
+    if [ "${OPTION,,}" == "enable" ]; then
+      just enable-zeliblue-cli
+    elif [ "${OPTION,,}" == "disable" ]; then
+      just disable-zeliblue-cli
+    fi
 
 [private]
 enable-zeliblue-cli:

--- a/config/files/shared/share/ublue-os/just/60-custom.just
+++ b/config/files/shared/share/ublue-os/just/60-custom.just
@@ -72,6 +72,8 @@ enable-zeliblue-cli:
 
   systemctl --user enable --now podman-auto-update.timer
 
+  echo "Zeliblue CLI is now enabled."
+
 [private]
 disable-zeliblue-cli:
   #!/usr/bin/env bash
@@ -84,3 +86,5 @@ disable-zeliblue-cli:
   podman image rm ghcr.io/zelikos/zeliblue-cli:latest
 
   systemctl --user daemon-reload
+
+  echo "Zeliblue CLI is now disabled."

--- a/config/files/shared/share/ublue-os/just/60-custom.just
+++ b/config/files/shared/share/ublue-os/just/60-custom.just
@@ -32,7 +32,9 @@ remove-davinci:
   distrobox stop -Y davincibox
   distrobox rm -Y davincibox
 
-# Initialize Zeliblue CLI environment
+
+
+[private]
 enable-zeliblue-cli:
   #!/usr/bin/env bash
   mkdir -p ~/.config/containers/systemd
@@ -46,7 +48,7 @@ enable-zeliblue-cli:
 
   systemctl --user enable --now podman-auto-update.timer
 
-# Disable Zeliblue CLI
+[private]
 disable-zeliblue-cli:
   #!/usr/bin/env bash
   rm ~/.config/containers/systemd/zeliblue-cli.container

--- a/config/files/shared/share/ublue-os/just/60-custom.just
+++ b/config/files/shared/share/ublue-os/just/60-custom.just
@@ -75,9 +75,10 @@ enable-zeliblue-cli:
 [private]
 disable-zeliblue-cli:
   #!/usr/bin/env bash
-  rm ~/.config/containers/systemd/zeliblue-cli.container
 
   systemctl --user stop zeliblue-cli.service
+  rm ~/.config/containers/systemd/zeliblue-cli.container
+
   systemctl --user disable --now podman-auto-update.timer
 
   podman image rm ghcr.io/zelikos/zeliblue-cli:latest


### PR DESCRIPTION
Adds `zeliblue-cli` as a just command that leverages `ugum` to prompt users to enable or disable zeliblue-cli, rather than showing separate `enable-zeliblue-cli` and `disable-zeliblue-cli` commands to them. The latter two commands are still used by the new `zeliblue-cli` command to perform the respective operation.