### PR TITLE
docs(README): Recommend Bluefin and Bazzite instead of uBlue main

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Zeliblue Desktop](/repo_content/desktop1.webp?raw=true)
 
-Zeliblue is based off of [ublue-os/startingpoint](https://github.com/ublue-os/startingpoint), which eases the process of creating your own personalized image-based Fedora experience. For more detailed information, check out the [uBlue homepage](https://universal-blue.org/) and the [main uBlue repo](https://github.com/ublue-os/main/).
+Zeliblue is based off of [ublue-os/startingpoint](https://github.com/ublue-os/startingpoint), which eases the process of creating your own personalized image-based Fedora experience. For more detailed information, check out the [uBlue homepage](https://universal-blue.org/).
 
 Zeliblue features the GNOME desktop as the flagship experience. Notable changes include:
 
@@ -22,9 +22,9 @@ Zeliblue Plasma (zeliblue-kinoite) uses the Plasma desktop environment instead o
 
 ## Installation
 
-I recommend looking into either the [main uBlue images](https://universal-blue.org/images/) or [making your own](https://universal-blue.org/tinker/make-your-own/), but, if you want to, here's how you can use Zelibue on your system:
+For most users, I would recommend looking into either [Bluefin](https://projectbluefin.io/) or [Bazzite](https://bazzite.gg/), or, for tinkerers, I recommend [making your own](https://universal-blue.org/tinker/make-your-own/). Both of the former two projects have many more contributors and a much larger community for support, whereas Zeliblue is run by one sole maintainer.
 
-The recommended installation method is to use the latest ISO from [the Releases page](https://github.com/zelikos/zeliblue/releases/tag/auto-iso).
+With that being said, for those that do still want to give Zeliblue a try, the recommended installation method is to use the latest ISO from [the Releases page](https://github.com/zelikos/zeliblue/releases/tag/auto-iso).
 
 You can also rebase an existing Silverblue/Kinoite installation to the latest build:
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Zeliblue Plasma (zeliblue-kinoite) uses the Plasma desktop environment instead o
 
 ## Installation
 
-For most users, I would recommend looking into either [Bluefin](https://projectbluefin.io/) or [Bazzite](https://bazzite.gg/), or, for tinkerers, I recommend [making your own](https://universal-blue.org/tinker/make-your-own/). Both of the former two projects have many more contributors and a much larger community for support, whereas Zeliblue is run by one sole maintainer.
+For most users, I would recommend looking into either [Bluefin](https://projectbluefin.io/) or [Bazzite](https://bazzite.gg/), or, for tinkerers, I recommend [making your own](https://universal-blue.org/tinker/make-your-own/). Both of the former two projects have many more contributors and a much larger community for support, whereas Zeliblue is run by one lone maintainer.
 
 With that being said, for those that do still want to give Zeliblue a try, the recommended installation method is to use the latest ISO from [the Releases page](https://github.com/zelikos/zeliblue/releases/tag/auto-iso).
 

--- a/README.md
+++ b/README.md
@@ -63,13 +63,9 @@ The full path to the installer is required, even if in the current directory.
 
 Removes DaVinci Resolve app launchers and davincibox container.
 
-### enable-zeliblue-cli
+### zeliblue-cli
 
-Enable an auto-updating `zeliblue` distrobox intended as the default CLI experience. The `zeliblue-cli` image is derived from [Universal Blue's fedora-toolbox](https://github.com/ublue-os/toolboxes).
-
-### disable-zeliblue-cli
-
-Removes the `zeliblue-cli` image and disables other related changes made by the previous command.
+Enable or disable an auto-updating `zeliblue` distrobox intended as the default CLI experience. The `zeliblue-cli` image is derived from [Universal Blue's fedora-toolbox](https://github.com/ublue-os/toolboxes).
 
 ## Scope
 


### PR DESCRIPTION
The `main` images are moreso intended as starting points for people to build their own images, whereas Bluefin and Bazzite are the "products" that showcase what you can do with the tech. It's better to direct people towards those two than uBlue main images, or to direct tinkerers toward building their own.

This also fixes the documentation on the `zeliblue-cli` command from #170 because I always forget to do README updates