### PR TITLE
feat(just): Use toolbox for davincibox commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,15 +49,13 @@ For more about `just`, see [the manual](https://just.systems/man/en/).
 
 ### setup-davincibox
 
-Sets up a [davincibox](https://github.com/zelikos/davincibox) container with distrobox. Optionally takes "refresh" as a parameter to rebuild the container with the latest version of davincibox.
+Sets up a [davincibox](https://github.com/zelikos/davincibox) container with toolbox. Optionally takes "refresh" as a parameter to rebuild the container with the latest version of davincibox.
 
 ### install-davinci
 
 Uses the `setup-davincibox` command, then installs DaVinci Resolve into davincibox, which also adds launchers to the app grid/menu for ease of use. DaVinci Resolve must be downloaded from [their website](https://www.blackmagicdesign.com/products/davinciresolve), and the installer passed to the command as a parameter.
 
 Example: `just install-davinci /full/path/to/DaVinci_Resolve_18.5.1_Linux.run`
-
-The full path to the installer is required, even if in the current directory.
 
 ### remove-davinci
 

--- a/config/files/shared/share/ublue-os/just/60-custom.just
+++ b/config/files/shared/share/ublue-os/just/60-custom.just
@@ -16,13 +16,15 @@ setup-davincibox mode="":
 install-davinci installer="":
   #!/usr/bin/env bash
   just setup-davincibox
-  if [[ $(echo {{installer}}) == "" ]]; then
-    echo "Please re-run this command with the path to DaVinci Resolve's installer."
-    echo "The full path is needed, even if in the current directory."
+
+  INSTALLER_FILE=$(readlink -e {{installer}})
+
+  if [[ $(echo $INSTALLER_FILE) == "" ]]; then
+    echo "Please re-run this command with the full path to the DaVinci Resolve's installer."
     echo "Example:"
     echo "just install-davinci /full/path/to/DaVinci_Resolve_18.5.1_Linux.run"
   else
-    toolbox run --container davincibox setup-davinci {{installer}} toolbox
+    toolbox run --container davincibox setup-davinci $INSTALLER_FILE toolbox
   fi
 
 # Remove DaVinci Resolve and DaVinciBox

--- a/config/files/shared/share/ublue-os/just/60-custom.just
+++ b/config/files/shared/share/ublue-os/just/60-custom.just
@@ -6,11 +6,11 @@
 setup-davincibox mode="":
   #!/usr/bin/env bash
   if [[ $(echo {{mode}}) == "refresh" ]]; then
-    distrobox stop -Y davincibox
-    distrobox rm -Y davincibox
+    podman container stop davincibox
+    podman container rm davincibox
   fi
   podman image pull ghcr.io/zelikos/davincibox:latest
-  distrobox create -i ghcr.io/zelikos/davincibox:latest -n davincibox
+  toolbox create -i ghcr.io/zelikos/davincibox:latest -c davincibox
 
 # Install DaVinci Resolve to DaVinciBox
 install-davinci installer="":
@@ -22,15 +22,15 @@ install-davinci installer="":
     echo "Example:"
     echo "just install-davinci /full/path/to/DaVinci_Resolve_18.5.1_Linux.run"
   else
-    distrobox enter davincibox -- setup-davinci {{installer}} distrobox
+    toolbox run --container davincibox setup-davinci {{installer}} toolbox
   fi
 
 # Remove DaVinci Resolve and DaVinciBox
 remove-davinci:
   #!/usr/bin/env bash
-  distrobox enter davincibox -- add-davinci-launcher remove
-  distrobox stop -Y davincibox
-  distrobox rm -Y davincibox
+  toolbox run --container davincibox add-davinci-launcher remove
+  podman container stop davincibox
+  podman container rm davincibox
 
 # Toggle Zeliblue-CLI
 zeliblue-cli ACTION="prompt":


### PR DESCRIPTION
Use toolbox for `davincibox`-related `just` commands instead of distrobox, to avoid the extra overhead/package installation of running distrobox.