### PR TITLE
fix(just): Add `changelogs` to 10-update.just

### DIFF
--- a/config/files/shared/usr/share/ublue-os/just/10-update.just
+++ b/config/files/shared/usr/share/ublue-os/just/10-update.just
@@ -7,3 +7,9 @@ update:
   #!/usr/bin/bash
   /usr/bin/topgrade --config /usr/share/ublue-update/topgrade-system.toml
   /usr/bin/topgrade --config /usr/share/ublue-update/topgrade-user.toml --keep
+
+alias changelog := changelogs
+
+ # Show the changelog
+ changelogs:
+     rpm-ostree db diff --changelogs


### PR DESCRIPTION
The `changelogs` command was moved into `10-update.just` upstream; since we're overriding that file with our own, this PR adds the command into ours.