### PR TITLE
feat(gnome): Add Hot Edge shell extension

### DIFF
--- a/config/common/gnome-config.yml
+++ b/config/common/gnome-config.yml
@@ -5,8 +5,11 @@ modules:
       - silverblue/usr: /usr
 
   - type: rpm-ostree
+    repos:
+      - https://copr.fedorainfracloud.org/coprs/kylegospo/bazzite/repo/fedora-%OS_VERSION%/kylegospo-bazzite-fedora-%OS_VERSION%.repo
     install:
       - gnome-console
+      - gnome-shell-extension-hotedge
     remove:
       - gnome-classic-session
       - gnome-software-rpm-ostree

--- a/config/common/gnome-config.yml
+++ b/config/common/gnome-config.yml
@@ -5,11 +5,8 @@ modules:
       - silverblue/usr: /usr
 
   - type: rpm-ostree
-    repos:
-      - https://copr.fedorainfracloud.org/coprs/kylegospo/bazzite/repo/fedora-%OS_VERSION%/kylegospo-bazzite-fedora-%OS_VERSION%.repo
     install:
       - gnome-console
-      - gnome-shell-extension-hotedge
     remove:
       - gnome-classic-session
       - gnome-software-rpm-ostree

--- a/config/gschema-overrides/zz0-zeliblue.gschema.override
+++ b/config/gschema-overrides/zz0-zeliblue.gschema.override
@@ -10,6 +10,7 @@ font-name="Inter 11"
 
 [org.gnome.shell]
 favorite-apps = ['org.gnome.Nautilus.desktop', 'org.gnome.Epiphany.desktop', 'org.gnome.Calendar.desktop', 'org.gnome.World.PikaBackup.desktop', 'org.gnome.Software.desktop', 'org.gnome.Settings.desktop']
+enabled-extensions = ['hotedge@jonathan.jdoda.ca']
 
 [org.gnome.Console]
 shell = ['fish']

--- a/config/recipes/gnome/zeliblue.yml
+++ b/config/recipes/gnome/zeliblue.yml
@@ -13,8 +13,3 @@ modules:
 
   - from-file: common/common-config.yml
   - from-file: common/gnome-config.yml
-  - type: rpm-ostree
-    repos:
-      - https://copr.fedorainfracloud.org/coprs/kylegospo/bazzite/repo/fedora-%OS_VERSION%/kylegospo-bazzite-fedora-%OS_VERSION%.repo
-    install:
-      - gnome-shell-extension-hotedge

--- a/config/recipes/gnome/zeliblue.yml
+++ b/config/recipes/gnome/zeliblue.yml
@@ -13,3 +13,8 @@ modules:
 
   - from-file: common/common-config.yml
   - from-file: common/gnome-config.yml
+  - type: rpm-ostree
+    repos:
+      - https://copr.fedorainfracloud.org/coprs/kylegospo/bazzite/repo/fedora-%OS_VERSION%/kylegospo-bazzite-fedora-%OS_VERSION%.repo
+    install:
+      - gnome-shell-extension-hotedge


### PR DESCRIPTION
Leverages the Bazzite COPR repository for the `gnome-shell-extension-hotedge` package, and enables the extension in gschema-overrides.

Closes #193 