### PR TITLE
feat: Deprecate Zeliblue GTS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,9 +25,9 @@ jobs:
         recipe:
           # !! Add your recipes here
           - recipes/gnome/zeliblue.yml
-          - recipes/gnome/zeliblue-gts.yml
           - recipes/plasma/zeliblue-kinoite.yml
           # - recipes/gnome/zeliblue-deck.yml
+          # - recipes/gnome/zeliblue-gts.yml
     steps:
        # the build is fully handled by the reusable github action
       - name: Build Custom Image

--- a/README.md
+++ b/README.md
@@ -8,17 +8,14 @@ Notable changes from vanilla GNOME and Fedora Silverblue include:
 
 - Workspace navigation shortcuts are adjusted, with the aim of being more intuitive for horizontal workspaces
 - GNOME Console replaces GNOME Terminal as the default terminal, and can be launched with Super+t
+- `fish` is set as the default shell in Console
 - Flathub is set up in the background on first boot, both system-wide (flathub-system) and for per-user installs (flathub-user)
 - GNOME Software defaults to installing apps from flathub-user
 - Core system apps are installed to flathub-system after first boot
 - System apps are selected based on the official [GNOME Core apps](https://apps.gnome.org/), with some substitutions and additions
 - And more miscellaneous tweaks
 
-There are also some additional flavors of Zeliblue:
-
-Zeliblue GTS, which is nearly identical to the main image. The difference is that GTS follows the latest version of Fedora, minus one. In other words, when Zeliblue is on Fedora 39, GTS is on Fedora 38. While the main image should work well for most users, GTS is provided for those that desire extra stability.
-
-Zeliblue Plasma (zeliblue-kinoite) uses the Plasma desktop environment instead of GNOME. It replaces multiple apps that are layered into the upstream image with Flatpak equivalents, as well as using `fish` as the default shell in Konsole.
+There is also Zeliblue Plasma (zeliblue-kinoite), which uses the Plasma desktop environment instead of GNOME. It replaces multiple apps that are layered into the upstream image with Flatpak equivalents, as well as using `fish` as the default shell in Konsole.
 
 Zeliblue is made with [BlueBuild](https://blue-build.org/).
 


### PR DESCRIPTION
- Disables zeliblue-gts builds
- Removes mention of GTS from the README
- Adds a mention that `fish` is the default shell in Console while we're here

Closes #195 