### PR TITLE
fix: Remove zeliblue-gts from boot_menu

### DIFF
--- a/boot_menu.yml
+++ b/boot_menu.yml
@@ -4,7 +4,5 @@ ublue_variants:
     flavors:
       - label: zeliblue
         info: The main Zeliblue experience
-      - label: zeliblue-gts
-        info: Zeliblue GTS, for extra stability
       - label: zeliblue-kinoite
         info: Zeliblue with the KDE Plasma Desktop


### PR DESCRIPTION
This was left in as an oversight from GTS's removal in #196.