### PR TITLE
feat: Improve manual updates

### DIFF
--- a/config/files/shared/usr/share/applications/system-update.desktop
+++ b/config/files/shared/usr/share/applications/system-update.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Type=Application
+Name=System Update
+Comment=Update system, apps, containers, and more
+Icon=software-update-available-symbolic
+Categories=ConsoleOnly;System;
+Terminal=true
+Exec=/usr/bin/ujust update

--- a/config/files/shared/usr/share/ublue-os/just/10-update.just
+++ b/config/files/shared/usr/share/ublue-os/just/10-update.just
@@ -5,8 +5,7 @@ alias upgrade := update
 # Upgrade system, containers, and brew
 update:
   #!/usr/bin/bash
-  /usr/bin/topgrade --config /usr/share/ublue-update/topgrade-system.toml
-  /usr/bin/topgrade --config /usr/share/ublue-update/topgrade-user.toml --keep
+  /usr/bin/topgrade --config /usr/share/zeliblue/topgrade.toml --keep
 
 alias changelog := changelogs
 

--- a/config/files/shared/usr/share/ublue-os/just/10-update.just
+++ b/config/files/shared/usr/share/ublue-os/just/10-update.just
@@ -7,6 +7,34 @@ update:
   #!/usr/bin/bash
   /usr/bin/topgrade --config /usr/share/zeliblue/topgrade.toml --keep
 
+alias auto-update := toggle-updates
+
+# Turn automatic updates on or off
+toggle-updates ACTION="prompt":
+    #!/usr/bin/bash
+    source /usr/lib/ujust/ujust.sh
+    CURRENT_STATE="Disabled"
+    if systemctl is-enabled ublue-update.timer | grep -q enabled; then
+      CURRENT_STATE="Enabled"
+    fi
+    OPTION={{ ACTION }}
+    if [ "$OPTION" == "prompt" ]; then
+      echo "Automatic updates are currently: ${bold}${CURRENT_STATE}${normal}"
+      echo "Enable or Disable automatic updates?"
+      OPTION=$(ugum choose Enable Disable)
+    elif [ "$OPTION" == "help" ]; then
+      echo "Usage: ujust toggle-updates <option>"
+      echo "  <option>: Specify the quick option - 'enable' or 'disable'"
+      echo "  Use 'enable' to Enable automatic updates."
+      echo "  Use 'disable' to Disable automatic updates."
+      exit 0
+    fi
+    if [ "${OPTION,,}" == "enable" ]; then
+      sudo systemctl enable ublue-update.timer
+    elif [ "${OPTION,,}" == "disable" ]; then
+      sudo systemctl disable ublue-update.timer
+    fi
+
 alias changelog := changelogs
 
 # Show the changelog

--- a/config/files/shared/usr/share/ublue-os/just/10-update.just
+++ b/config/files/shared/usr/share/ublue-os/just/10-update.just
@@ -2,7 +2,7 @@
 
 alias upgrade := update
 
-# Upgrade system, containers, and brew
+# Upgrade system, apps, and containers
 update:
   #!/usr/bin/bash
   /usr/bin/topgrade --config /usr/share/zeliblue/topgrade.toml --keep

--- a/config/files/shared/usr/share/zeliblue/topgrade.toml
+++ b/config/files/shared/usr/share/zeliblue/topgrade.toml
@@ -1,13 +1,16 @@
 [misc]
-only = ["brew_cask", "brew_formula", "distrobox", "system", "toolbx"]
-ignore_failures = ["brew_cask", "brew_formula", "distrobox", "toolbx"]
+only = ["brew_cask", "brew_formula", "distrobox", "flatpak", "firmware", "system", "toolbx"]
+ignore_failures = ["brew_cask", "brew_formula", "distrobox","flatpak", "toolbx"]
 skip_notify = true
 assume_yes = true
-no_retry = true
+no_retry = false
 no_self_update = true
 
 [distrobox]
 use_root = false
+
+[flatpak]
+use_sudo = false
 
 [linux]
 rpm_ostree = true

--- a/config/files/shared/usr/share/zeliblue/topgrade.toml
+++ b/config/files/shared/usr/share/zeliblue/topgrade.toml
@@ -1,0 +1,13 @@
+[misc]
+only = ["brew_cask", "brew_formula", "distrobox", "system", "toolbx"]
+ignore_failures = ["brew_cask", "brew_formula", "distrobox", "toolbx"]
+skip_notify = true
+assume_yes = true
+no_retry = true
+no_self_update = true
+
+[distrobox]
+use_root = false
+
+[linux]
+rpm_ostree = true


### PR DESCRIPTION
- Points `just update` to a dedicated topgrade config file, which includes everything from auto-updates plus flatpaks and firmware
- Re-adds the auto-updates toggle
- Adds a launcher for running system updates from the GUI

Closes #206 