### PR TITLE
feat: Add motd tip for brew

### DIFF
--- a/config/files/shared/usr/share/ublue-os/just/60-custom.just
+++ b/config/files/shared/usr/share/ublue-os/just/60-custom.just
@@ -42,6 +42,7 @@ brew-utilities:
     fi
     echo "Installing Zeliblue CLI utilities..."
     brew bundle --file=$HOME/.local/share/zeliblue/Brewfile
+    echo "Utilities installed. Please restart your terminal."
   #elif [ "${OPTION,,}" == "no" ]; then
   #  just disable-zeliblue-cli
   fi

--- a/config/files/shared/usr/share/zeliblue/motd/tips/10-tips.md
+++ b/config/files/shared/usr/share/zeliblue/motd/tips/10-tips.md
@@ -5,4 +5,4 @@ Zeliblue is built using 󰣛 [Fedora Atomic Desktop](https://fedoraproject.org/a
 Zeliblue is made possible by [Universal Blue](https://universal-blue.org) and [BlueBuild](https://blue-build.org)
 Like servers? Check out [ucore](https://github.com/ublue-os/ucore)
 Update break something? You can roll back and pin the previous release or build date:~[View the Universal Blue guide](https://universal-blue.discourse.group/docs?topic=513)
-Use `brew search` and `brew install` to find and install basic CLI utilities. Updates are handled automatically
+Use `brew search` and `brew install` to find and install basic utilities. Updates are handled automatically

--- a/config/files/shared/usr/share/zeliblue/motd/tips/10-tips.md
+++ b/config/files/shared/usr/share/zeliblue/motd/tips/10-tips.md
@@ -5,3 +5,4 @@ Zeliblue is built using 󰣛 [Fedora Atomic Desktop](https://fedoraproject.org/a
 Zeliblue is made possible by [Universal Blue](https://universal-blue.org) and [BlueBuild](https://blue-build.org)
 Like servers? Check out [ucore](https://github.com/ublue-os/ucore)
 Update break something? You can roll back and pin the previous release or build date:~[View the Universal Blue guide](https://universal-blue.discourse.group/docs?topic=513)
+Use `brew search` and `brew install` to find and install basic CLI utilities. Updates are handled automatically

--- a/config/files/shared/usr/share/zeliblue/motd/zeliblue.md
+++ b/config/files/shared/usr/share/zeliblue/motd/zeliblue.md
@@ -6,6 +6,7 @@
 | `ujust`  | List all available commands |
 | `ujust toggle-user-motd` | Toggle this banner on/off |
 | `ujust brew` | Install Homebrew (Strongly Recommended) |
+| `ujust brew-utilities` | Install some utilities with brew to spice up your terminal
 
 %TIP%
 

--- a/config/files/shared/usr/share/zeliblue/motd/zeliblue.md
+++ b/config/files/shared/usr/share/zeliblue/motd/zeliblue.md
@@ -6,7 +6,7 @@
 | `ujust`  | List all available commands |
 | `ujust toggle-user-motd` | Toggle this banner on/off |
 | `ujust brew` | Install Homebrew (Strongly Recommended) |
-| `ujust brew-utilities` | Install some utilities with brew to spice up your terminal
+| `ujust brew-utilities` | Install some utilities with brew to spice up your terminal |
 
 %TIP%
 


### PR DESCRIPTION
- Adds a tip for `brew`, using the phrasing "install basic utilities" to encourage lighter use of brew, since heavier development needs should be done in containers.
- Adds mention of brew-utilities to the MOTD.
- Adds notice for the user to restart their terminal after `just brew-utilities` completes