### PR TITLE
fix: Remove brew install, as it's in ublue-os/config now

### DIFF
--- a/config/files/shared/usr/etc/profile.d/brew.sh
+++ b/config/files/shared/usr/etc/profile.d/brew.sh
@@ -1,3 +1,0 @@
-if [[ -x "/home/linuxbrew/.linuxbrew/bin/brew" ]]; then
-  [[ $- == *i* ]] && eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-fi

--- a/config/files/shared/usr/share/ublue-os/just/60-custom.just
+++ b/config/files/shared/usr/share/ublue-os/just/60-custom.just
@@ -1,24 +1,5 @@
 # Include some of your custom scripts here!
 
-# Install Homebrew
-brew:
-  #!/usr/bin/env bash
-  if [[ ! -x "/var/home/linuxbrew/.linuxbrew/bin/brew" ]]; then
-    echo "Brew Installation"
-    echo "At the end of installation, the Brew installer will have a \"Next steps\" section."
-    echo "In Zeliblue, the steps listed for adding homebrew to your PATH are not necessary,"
-    echo "as they are already pre-configured. All you'll have to do is close and re-open the terminal!"
-    echo "Please type in \"I understand\" to proceed with brew installation."
-    read ACCEPT
-    if [ "$ACCEPT" == "I understand" ]; then
-      /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-    else
-      echo "Capitalization matters when you type \"I understand\""
-    fi
-  else
-    echo "Brew is already installed."
-  fi
-
 # Install a small selection of CLI utilties via brew
 brew-utilities:
   #!/usr/bin/bash


### PR DESCRIPTION
Removes the `brew` command from our `custom.just` as well as the `brew.sh` bash profile script, as both are now upstream in ublue-os/config