### PR TITLE
feat: Add templates for bash scripts and plain text files

### DIFF
--- a/config/files/shared/usr/etc/skel/Templates/Untitled Script.sh
+++ b/config/files/shared/usr/etc/skel/Templates/Untitled Script.sh
@@ -1,0 +1,1 @@
+#!/usr/bin/env bash


### PR DESCRIPTION
Adds templates for creating blank bash script and plain text files from supporting file managers, like GNOME Files. We might add more later, but this is a starting point.

Closes #203 