### PR TITLE
feat(gnome): Enable System76 Scheduler extension by default

### DIFF
--- a/config/gschema-overrides/zz0-zeliblue.gschema.override
+++ b/config/gschema-overrides/zz0-zeliblue.gschema.override
@@ -7,7 +7,7 @@ font-name="Inter 11"
 
 [org.gnome.shell]
 favorite-apps = ['org.gnome.Nautilus.desktop', 'org.gnome.Epiphany.desktop', 'org.gnome.Calendar.desktop', 'org.gnome.World.PikaBackup.desktop', 'org.gnome.Software.desktop', 'org.gnome.Settings.desktop']
-enabled-extensions = ['hotedge@jonathan.jdoda.ca']
+enabled-extensions = ['hotedge@jonathan.jdoda.ca', 's76-scheduler@mattjakeman.com']
 
 [org.gnome.Console]
 shell = ['fish']


### PR DESCRIPTION
Enables the S76 scheduler GNOME extension by default, after its addition in #220 