### PR TITLE
fix: Improve Ptyxis integration

### DIFF
--- a/files/system_files/gnome/usr/bin/xdg-terminal-exec
+++ b/files/system_files/gnome/usr/bin/xdg-terminal-exec
@@ -1,0 +1,17 @@
+#!/usr/bin/bash
+
+if command -v /usr/bin/ptyxis > /dev/null; then
+  if [[ -z "$@" ]]; then
+    /usr/bin/ptyxis --new-window
+  else
+    /usr/bin/ptyxis -- "$@"
+  fi
+elif grep '^org\.gnome\.Ptyxis$' <<< $(/usr/bin/flatpak list --app --columns=application); then
+  if [[ -z "$@" ]]; then
+    /usr/bin/flatpak run org.gnome.Ptyxis --new-window
+  else
+    /usr/bin/flatpak run org.gnome.Ptyxis -- "$@"
+  fi
+else
+  /usr/bin/gnome-terminal -- "$@"
+fi

--- a/files/system_files/gnome/usr/bin/xdg-terminal-exec
+++ b/files/system_files/gnome/usr/bin/xdg-terminal-exec
@@ -1,4 +1,5 @@
 #!/usr/bin/bash
+# Imported from Bluefin: https://github.com/ublue-os/bluefin/blob/main/system_files/silverblue/usr/bin/xdg-terminal-exec
 
 if command -v /usr/bin/ptyxis > /dev/null; then
   if [[ -z "$@" ]]; then

--- a/files/system_files/gnome/usr/etc/dconf/db/local.d/01-zeliblue-keybindings
+++ b/files/system_files/gnome/usr/etc/dconf/db/local.d/01-zeliblue-keybindings
@@ -1,6 +1,6 @@
 [org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0]
 binding='<Super>t'
-command='ptyxis'
+command='xdg-terminal-exec'
 name="Launch terminal"
 
 [org/gnome/settings-daemon/plugins/media-keys]


### PR DESCRIPTION
Imports `xdg-terminal-exec` implementation from Bluefin to fix Ptyxis integration as the default terminal.