### PR TITLE
fix: Alias fastfetch to use fedora-silverblue logo

### DIFF
--- a/files/system_files/shared/etc/profile.d/zeliblue-fastfetch.sh
+++ b/files/system_files/shared/etc/profile.d/zeliblue-fastfetch.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+alias fastfetch='fastfetch --logo fedora-silverblue'

--- a/files/system_files/shared/usr/share/fish/vendor_conf.d/zeliblue-fastfetch.fish
+++ b/files/system_files/shared/usr/share/fish/vendor_conf.d/zeliblue-fastfetch.fish
@@ -1,0 +1,3 @@
+#!/usr/bin/fish
+#shellcheck disable=all
+alias fastfetch="fastfetch --logo fedora-silverblue"


### PR DESCRIPTION
Since the ID in os-release was changed to `zeliblue` in #237, fastfetch is using a generic Linux logo instead of Fedora's. This sets fastfetch to use the `fedora-silverblue` logo instead, until we have a custom logo.