### PR TITLE
fix: Move brew updates to manual update config

### DIFF
--- a/files/system_files/shared/usr/share/ublue-update/topgrade-system.toml
+++ b/files/system_files/shared/usr/share/ublue-update/topgrade-system.toml
@@ -1,6 +1,5 @@
 [misc]
-only = ["brew_cask", "brew_formula", "system"]
-ignore_failures = ["brew_cask", "brew_formula"]
+only = ["system"]
 skip_notify = true
 assume_yes = true
 no_retry = true

--- a/files/system_files/shared/usr/share/zeliblue/topgrade.toml
+++ b/files/system_files/shared/usr/share/zeliblue/topgrade.toml
@@ -1,6 +1,20 @@
 [misc]
-only = ["distrobox", "flatpak", "firmware", "system", "toolbx"]
-ignore_failures = ["distrobox","flatpak", "toolbx"]
+only = [
+    "brew_cask",
+    "brew_formula",
+    "distrobox",
+    "flatpak",
+    "firmware",
+    "system",
+    "toolbx",
+]
+ignore_failures = [
+    "brew_cask",
+    "brew_formula",
+    "distrobox",
+    "flatpak",
+    "toolbx",
+]
 skip_notify = true
 assume_yes = true
 no_retry = false


### PR DESCRIPTION
I derped when removing brew updates from `/usr/share/zeliblue/topgrade.toml` in a previous PR, which is sourced by our `just update` command; those are manual updates, where we do want *everything* relevant to be updated.

This moves brew updates from the `/usr/share/ublue-update/topgrade-system.toml` (used by ublue-update for automatic updates) into the manual update topgrade config, because automatic brew updates are handled by dedicated systemd services already.