### PR TITLE
build: Add `stable` and `testing` tags

### DIFF
--- a/.github/workflows/build-iso.yml
+++ b/.github/workflows/build-iso.yml
@@ -11,7 +11,7 @@ on:
     branches:
       - main
     paths:
-      - '.github/workflows/build_iso.yml'
+      - ".github/workflows/build_iso.yml"
 
 env:
   IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
@@ -32,7 +32,7 @@ jobs:
       matrix:
         image_name: [zeliblue]
         major_version: [40]
-        image_tag: [latest]
+        image_tag: [stable]
 
     steps:
       - name: Fetch current date
@@ -53,9 +53,9 @@ jobs:
           image_repo: ${{ env.IMAGE_REGISTRY }}
           image_name: ${{ matrix.image_name }}
           image_tag: ${{ matrix.image_tag }}
-          variant: 'Silverblue'
-          enrollment_password: 'ublue-os'
-          secure_boot_key_url: 'https://github.com/ublue-os/akmods/raw/main/certs/public_key.der'
+          variant: "Silverblue"
+          enrollment_password: "ublue-os"
+          secure_boot_key_url: "https://github.com/ublue-os/akmods/raw/main/certs/public_key.der"
           iso_name: ${{ matrix.image_name }}.iso
           enable_cache_dnf: "false"
           enable_cache_skopeo: "false"
@@ -71,7 +71,7 @@ jobs:
           mkdir ${ISO_UPLOAD_DIR}
           mv ${{ steps.build.outputs.iso_path }}/${{ steps.build.outputs.iso_name }} ${ISO_UPLOAD_DIR}
           mv ${{ steps.build.outputs.iso_path }}/${{ steps.build.outputs.iso_name }}-CHECKSUM ${ISO_UPLOAD_DIR}
-          echo "iso-upload-dir=${ISO_UPLOAD_DIR}" >> $GITHUB_OUTPUT     
+          echo "iso-upload-dir=${ISO_UPLOAD_DIR}" >> $GITHUB_OUTPUT
 
       - name: Upload ISO to R2 Zeliblue Bucket
         if: github.ref_name == 'main'

--- a/recipes/cosmic/zeliblue-cosmic.yml
+++ b/recipes/cosmic/zeliblue-cosmic.yml
@@ -2,6 +2,8 @@
 name: zeliblue-cosmic
 # description will be included in the image's metadata
 description: An opinionated COSMIC desktop experience, based on Fedora Atomic
+alt-tags:
+  - testing
 
 # the base image to build on top of (FROM) and the version tag to use
 base-image: ghcr.io/ublue-os/cosmic

--- a/recipes/gnome/zeliblue.yml
+++ b/recipes/gnome/zeliblue.yml
@@ -2,6 +2,8 @@
 name: zeliblue
 # description will be included in the image's metadata
 description: An opinionated GNOME desktop experience, based on Fedora Silverblue
+alt-tags:
+  - stable
 
 # the base image to build on top of (FROM) and the version tag to use
 base-image: ghcr.io/ublue-os/silverblue-main

--- a/recipes/plasma/zeliblue-kinoite.yml
+++ b/recipes/plasma/zeliblue-kinoite.yml
@@ -2,6 +2,8 @@
 name: zeliblue-kinoite
 # description will be included in the image's metadata
 description: Zeliblue, with KDE Plasma
+alt-tags:
+  - stable
 
 # the base image to build on top of (FROM) and the version tag to use
 base-image: ghcr.io/ublue-os/kinoite-main


### PR DESCRIPTION
`stable` will replace `latest` as the intended tag for most users to be on. `testing` will be used for experimental changes and images, such as Zeliblue COSMIC. The kernel replacement with the fsync kernel that is currently done in all builds will also be moved into `testing` branches in another PR, as Bluefin is reverting their own switch to the fsync kernel and I want to do the same for `stable` images here.