### PR TITLE
feat(image-info): Set IMAGE_TAG from recipe

### DIFF
--- a/files/scripts/image-info.sh
+++ b/files/scripts/image-info.sh
@@ -47,7 +47,7 @@ sed -i "s|^SUPPORT_URL=.*|SUPPORT_URL=\"$SUPPORT_URL\"|" /usr/lib/os-release
 sed -i "s|^BUG_REPORT_URL=.*|BUG_REPORT_URL=\"$BUG_REPORT_URL\"|" /usr/lib/os-release
 sed -i "s|^CPE_NAME=\"cpe:/o:fedoraproject:fedora|CPE_NAME=\"cpe:/o:zelikos:${IMAGE_PRETTY_NAME,}|" /usr/lib/os-release
 sed -i "s/^DEFAULT_HOSTNAME=.*/DEFAULT_HOSTNAME=\"${IMAGE_PRETTY_NAME,}\"/" /usr/lib/os-release
-sed -i "s/^ID=fedora/ID=${IMAGE_PRETTY_NAME,}\nID_LIKE=\"rhel centos fedora\"/" /usr/lib/os-release
+sed -i "s/^ID=fedora/ID=${IMAGE_PRETTY_NAME,}\nID_LIKE=\"fedora\"/" /usr/lib/os-release
 # sed -i "s/^LOGO=.*/LOGO=$LOGO_ICON/" /usr/lib/os-release
 # sed -i "s/^ANSI_COLOR=.*/ANSI_COLOR=\"$LOGO_COLOR\"/" /usr/lib/os-release
 sed -i "/^REDHAT_BUGZILLA_PRODUCT=/d; /^REDHAT_BUGZILLA_PRODUCT_VERSION=/d; /^REDHAT_SUPPORT_PRODUCT=/d; /^REDHAT_SUPPORT_PRODUCT_VERSION=/d" /usr/lib/os-release

--- a/files/scripts/image-info.sh
+++ b/files/scripts/image-info.sh
@@ -17,7 +17,7 @@ IMAGE_INFO="/usr/share/zeliblue/image-info.json"
 IMAGE_VENDOR="zelikos"
 IMAGE_REF="ostree-image-signed:docker://ghcr.io/$IMAGE_VENDOR/$IMAGE_NAME"
 IMAGE_FLAVOR=""
-IMAGE_TAG="latest"
+IMAGE_TAG="$ZELIBLUE_IMAGE_TAG"
 
 if grep -q "kinoite" <<< "${BASE_IMAGE}"; then
   IMAGE_FLAVOR="kinoite"

--- a/recipes/cosmic/zeliblue-cosmic.yml
+++ b/recipes/cosmic/zeliblue-cosmic.yml
@@ -12,6 +12,10 @@ image-version: latest-amd64
 # list of modules, executed in order
 # you can include multiple instances of the same module
 modules:
+  - type: containerfile
+    snippets:
+      - ARG ZELIBLUE_IMAGE_TAG=testing
+
   # - from-file: common/common-akmods.yml
   - from-file: common/common-bling.yml
   - from-file: common/common-files.yml

--- a/recipes/gnome/zeliblue-testing.yml
+++ b/recipes/gnome/zeliblue-testing.yml
@@ -12,6 +12,10 @@ image-version: latest
 # list of modules, executed in order
 # you can include multiple instances of the same module
 modules:
+  - type: containerfile
+    snippets:
+      - ARG ZELIBLUE_IMAGE_TAG=testing
+
   # - from-file: common/common-akmods.yml
   - from-file: common/common-bling.yml
   - from-file: common/common-files.yml

--- a/recipes/gnome/zeliblue.yml
+++ b/recipes/gnome/zeliblue.yml
@@ -13,6 +13,10 @@ image-version: latest
 # list of modules, executed in order
 # you can include multiple instances of the same module
 modules:
+  - type: containerfile
+    snippets:
+      - ARG ZELIBLUE_IMAGE_TAG=stable
+
   # - from-file: common/common-kernel.yml
   - from-file: common/common-akmods.yml
   - from-file: common/common-bling.yml

--- a/recipes/plasma/zeliblue-kinoite.yml
+++ b/recipes/plasma/zeliblue-kinoite.yml
@@ -13,6 +13,10 @@ image-version: latest
 # module configuration, executed in order
 # you can include multiple instances of the same module
 modules:
+  - type: containerfile
+    snippets:
+      - ARG ZELIBLUE_IMAGE_TAG=stable
+
   # - from-file: common/common-kernel.yml
   - from-file: common/common-akmods.yml
   - from-file: common/common-bling.yml


### PR DESCRIPTION
This way we'll have the appropriate different tag for `stable` and `testing` images. Previously, this was hardcoded to being `latest`.