### PR TITLE
refactor: Add *-base.yml files for simpler config sharing

### DIFF
--- a/recipes/common/common-base.yml
+++ b/recipes/common/common-base.yml
@@ -1,0 +1,9 @@
+modules:
+  - from-file: common/common-akmods.yml
+  - from-file: common/common-bling.yml
+  - from-file: common/common-files.yml
+  - from-file: common/common-flatpaks.yml
+  - from-file: common/common-fonts.yml
+  - from-file: common/common-packages.yml
+  - from-file: common/common-scripts.yml
+  - from-file: common/common-modules.yml

--- a/recipes/gnome/gnome-base.yml
+++ b/recipes/gnome/gnome-base.yml
@@ -1,0 +1,5 @@
+modules:
+  - from-file: gnome/gnome-files.yml
+  - from-file: gnome/gnome-packages.yml
+  - from-file: gnome/gnome-flatpaks.yml
+  - from-file: gnome/gnome-gschemas.yml

--- a/recipes/gnome/zeliblue-testing.yml
+++ b/recipes/gnome/zeliblue-testing.yml
@@ -29,7 +29,4 @@ modules:
   - from-file: testing/testing-kernel.yml
   - from-file: testing/testing-packages.yml
 
-  - from-file: gnome/gnome-files.yml
-  - from-file: gnome/gnome-packages.yml
-  - from-file: gnome/gnome-flatpaks.yml
-  - from-file: gnome/gnome-gschemas.yml
+  - from-file: gnome/gnome-base.yml

--- a/recipes/gnome/zeliblue.yml
+++ b/recipes/gnome/zeliblue.yml
@@ -18,8 +18,4 @@ modules:
       - ARG ZELIBLUE_IMAGE_TAG=stable
 
   - from-file: common/common-base.yml
-
-  - from-file: gnome/gnome-files.yml
-  - from-file: gnome/gnome-packages.yml
-  - from-file: gnome/gnome-flatpaks.yml
-  - from-file: gnome/gnome-gschemas.yml
+  - from-file: gnome/gnome-base.yml

--- a/recipes/gnome/zeliblue.yml
+++ b/recipes/gnome/zeliblue.yml
@@ -17,16 +17,7 @@ modules:
     snippets:
       - ARG ZELIBLUE_IMAGE_TAG=stable
 
-  # - from-file: common/common-kernel.yml
-  - from-file: common/common-akmods.yml
-  - from-file: common/common-bling.yml
-  - from-file: common/common-files.yml
-  - from-file: common/common-flatpaks.yml
-  - from-file: common/common-fonts.yml
-  - from-file: common/common-packages.yml
-  - from-file: common/common-scripts.yml
-  #  - from-file: common/common-systemd.yml
-  - from-file: common/common-modules.yml
+  - from-file: common/common-base.yml
 
   - from-file: gnome/gnome-files.yml
   - from-file: gnome/gnome-packages.yml

--- a/recipes/plasma/plasma-base.yml
+++ b/recipes/plasma/plasma-base.yml
@@ -1,0 +1,4 @@
+modules:
+  - from-file: plasma/plasma-files.yml
+  - from-file: plasma/plasma-packages.yml
+  - from-file: plasma/plasma-flatpaks.yml

--- a/recipes/plasma/zeliblue-kinoite.yml
+++ b/recipes/plasma/zeliblue-kinoite.yml
@@ -17,16 +17,7 @@ modules:
     snippets:
       - ARG ZELIBLUE_IMAGE_TAG=stable
 
-  # - from-file: common/common-kernel.yml
-  - from-file: common/common-akmods.yml
-  - from-file: common/common-bling.yml
-  - from-file: common/common-files.yml
-  - from-file: common/common-flatpaks.yml
-  - from-file: common/common-fonts.yml
-  - from-file: common/common-packages.yml
-  - from-file: common/common-scripts.yml
-  # - from-file: common/common-systemd.yml
-  - from-file: common/common-modules.yml
+  - from-file: common/common-base.yml
 
   - from-file: plasma/plasma-files.yml
   - from-file: plasma/plasma-packages.yml

--- a/recipes/plasma/zeliblue-kinoite.yml
+++ b/recipes/plasma/zeliblue-kinoite.yml
@@ -18,7 +18,4 @@ modules:
       - ARG ZELIBLUE_IMAGE_TAG=stable
 
   - from-file: common/common-base.yml
-
-  - from-file: plasma/plasma-files.yml
-  - from-file: plasma/plasma-packages.yml
-  - from-file: plasma/plasma-flatpaks.yml
+  - from-file: plasma/plasma-base.yml


### PR DESCRIPTION
- Adds `common-base.yml` to act as a one-line include for all base configurations. This is nice for the `stable` recipes that shouldn't need to deviate on any of the `common` modules, whereas `testing` recipes might need to omit some of them.
- Adds `gnome-base.yml` and `plasma-base.yml` for similar reason as above. It may make sense to do the same for additional desktop environments in the future, too