### PR TITLE
fix: Hide launchers for CLI programs

### DIFF
--- a/files/scripts/hide-launchers.sh
+++ b/files/scripts/hide-launchers.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# Tell this script to exit if there are any errors.
+# You should have this in every custom script, to ensure that your completed
+# builds actually ran successfully without any errors!
+set -oue pipefail
+
+# Hide launchers for CLI programs
+sed -i 's@\[Desktop Entry\]@\[Desktop Entry\]\nNoDisplay=true@g' /usr/share/applications/fish.desktop
+sed -i 's@\[Desktop Entry\]@\[Desktop Entry\]\nNoDisplay=true@g' /usr/share/applications/htop.desktop
+sed -i 's@\[Desktop Entry\]@\[Desktop Entry\]\nNoDisplay=true@g' /usr/share/applications/nvtop.desktop

--- a/recipes/common/common-scripts.yml
+++ b/recipes/common/common-scripts.yml
@@ -1,3 +1,4 @@
 type: script
 scripts:
   - image-info.sh
+  - hide-launchers.sh


### PR DESCRIPTION
Programs like fish and htop include .desktop launchers, when it usually makes the most sense to use those directly from a terminal. Especially in the case of fish.