### PR TITLE
feat: Remove window management keybind overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ Zeliblue is a customized [Fedora Atomic Desktop](https://fedoraproject.org/atomi
 
 Notable changes from vanilla GNOME and Fedora Silverblue include:
 
-- Workspace navigation shortcuts are adjusted, with the aim of being more intuitive for horizontal workspaces
 - Ptyxis replaces GNOME Terminal as the default terminal, and can be launched with Super+t
 - `fish` is set as the default shell in Ptyxis
 - [Homebrew](https://brew.sh/) is enabled out of the box

--- a/files/gschema-overrides/zz0-zeliblue.gschema.override
+++ b/files/gschema-overrides/zz0-zeliblue.gschema.override
@@ -18,21 +18,9 @@ document-font-name="Inter 11"
 monospace-font-name="Hack Nerd Font Mono 10"
 gtk-theme="adw-gtk3"
 
-[org.gnome.desktop.wm.keybindings]
-move-to-workspace-1 = ['<Alt><Super>Home']
-move-to-workspace-last = ['<Alt><Super>End']
-move-to-workspace-left = ['<Alt><Super>Left']
-move-to-workspace-right = ['<Alt><Super>Right']
-switch-to-workspace-left = ['<Super>Left']
-switch-to-workspace-right = ['<Super>Right']
-
 [org.gnome.mutter]
 center-new-windows=true
 check-alive-timeout=uint32 20000
-
-[org.gnome.mutter.keybindings]
-toggle-tiled-left = ['<Control><Super>Left']
-toggle-tiled-right = ['<Control><Super>Right']
 
 [org.gnome.nautilus.icon-view]
 captions = ['size', 'date_modified', 'none']


### PR DESCRIPTION
Currently, Zeliblue changes some of the default keybindings for workspace navigation and window management. This was initially done with the goal of being "more intuitive for horizontal workspaces," taking inspiration from elementary OS's keybinds. The most obvious downside here is that anyone coming from vanilla GNOME would be thrown off due to muscle memory, as many distros that ship GNOME don't tend to change those keybinds (Pop!_OS >= 22.04 being the one exception I can think of). I've been reconsidering this change for a long while, and ultimately I think the defaults have some other advantages as well.

**Examples**

Window tiling
Zeliblue: Super+Ctrl+Left/Right
Default GNOME: Super+Left/Right

The latter requires fewer key presses and is also consistent with the maximize and restore shortcuts (Super+Up & Super+Down)

Changing workspaces
Zeliblue: Super+Left/Right
GNOME: Super+Page Up/Down

Zeliblue's may make sense for horizontal workspaces, but semantically I think that a workspace corresponding to a "page" with the Page Up/Down keybind does make sense. Similarly, moving windows between workspaces in GNOME is Super+Shift+Page Up/Down, i.e. you're "shifting" a window to another "page"