### PR TITLE
build: Add Zeliblue Bazzite

### DIFF
--- a/.github/workflows/build-testing.yml
+++ b/.github/workflows/build-testing.yml
@@ -19,6 +19,12 @@ jobs:
     secrets: inherit
     with:
       recipe: gnome/zeliblue-testing.yml
+  build_bazzite:
+    name: Zeliblue Bazzite Testing
+    uses: ./.github/workflows/reusable-build.yml
+    secrets: inherit
+    with:
+      recipe: gnome/zeliblue-bazzite.yml
   build_cosmic:
     name: Zeliblue COSMIC Testing
     uses: ./.github/workflows/reusable-build.yml

--- a/recipes/gnome/zeliblue-bazzite.yml
+++ b/recipes/gnome/zeliblue-bazzite.yml
@@ -17,7 +17,6 @@ modules:
       - ARG ZELIBLUE_PRETTY_NAME="Zeliblue Bazzite"
       - ARG ZELIBLUE_IMAGE_TAG=testing
 
-  # - from-file: common/common-base.yml
   - from-file: common/common-files.yml
   - from-file: common/common-flatpaks.yml
   - from-file: common/common-fonts.yml
@@ -34,4 +33,5 @@ modules:
       - rsms-inter-fonts.noarch
       - rsms-inter-vf-fonts
 
-  - from-file: gnome/gnome-base.yml
+  - from-file: gnome/gnome-files.yml
+  - from-file: gnome/gnome-gschemas.yml

--- a/recipes/gnome/zeliblue-bazzite.yml
+++ b/recipes/gnome/zeliblue-bazzite.yml
@@ -1,0 +1,21 @@
+# image will be published to ghcr.io/<user>/<name>
+name: zeliblue-bazzite
+# description will be included in the image's metadata
+description: A Bazzite-based Zeliblue experience
+alt-tags:
+  - testing
+
+# the base image to build on top of (FROM) and the version tag to use
+base-image: ghcr.io/ublue-os/bazzite-deck-gnome
+image-version: latest
+
+# list of modules, executed in order
+# you can include multiple instances of the same module
+modules:
+  - type: containerfile
+    snippets:
+      - ARG ZELIBLUE_PRETTY_NAME="Zeliblue Bazzite"
+      - ARG ZELIBLUE_IMAGE_TAG=testing
+
+  - from-file: common/common-base.yml
+  - from-file: gnome/gnome-base.yml

--- a/recipes/gnome/zeliblue-bazzite.yml
+++ b/recipes/gnome/zeliblue-bazzite.yml
@@ -17,5 +17,21 @@ modules:
       - ARG ZELIBLUE_PRETTY_NAME="Zeliblue Bazzite"
       - ARG ZELIBLUE_IMAGE_TAG=testing
 
-  - from-file: common/common-base.yml
+  # - from-file: common/common-base.yml
+  - from-file: common/common-files.yml
+  - from-file: common/common-flatpaks.yml
+  - from-file: common/common-fonts.yml
+
+  - type: script
+    scripts:
+      - image-info.sh
+
+  - type: signing
+
+  - type: rpm-ostree
+    install:
+      - micro
+      - rsms-inter-fonts.noarch
+      - rsms-inter-vf-fonts
+
   - from-file: gnome/gnome-base.yml


### PR DESCRIPTION
A successor to Zeliblue Deck images; uses `bazzite-deck-gnome` as the base image, instead of me manually recreating the bazzite-deck experience myself based on Bazzite's repository.