### PR TITLE
build(experimental): Zeliblue Deck minimal

### DIFF
--- a/recipes/gnome/zeliblue-testing.yml
+++ b/recipes/gnome/zeliblue-testing.yml
@@ -17,13 +17,7 @@ modules:
       - ARG ZELIBLUE_PRETTY_NAME="Zeliblue"
       - ARG ZELIBLUE_IMAGE_TAG=testing
 
-  - from-file: common/common-bling.yml
-  - from-file: common/common-files.yml
-  - from-file: common/common-flatpaks.yml
-  - from-file: common/common-fonts.yml
-  - from-file: common/common-packages.yml
-  - from-file: common/common-scripts.yml
-  - from-file: common/common-modules.yml
+  - from-file: common/common-base.yml
 
   - from-file: testing/testing-kernel.yml
   - from-file: testing/testing-packages.yml

--- a/recipes/testing/testing-packages.yml
+++ b/recipes/testing/testing-packages.yml
@@ -5,4 +5,6 @@ repos:
 install:
   - gamescope-session-plus
   - gamescope-session-steam
+  - mangohud
   - scx-scheds
+  - steam

--- a/recipes/testing/testing-packages.yml
+++ b/recipes/testing/testing-packages.yml
@@ -1,5 +1,8 @@
 type: rpm-ostree
 repos:
+  - https://copr.fedorainfracloud.org/coprs/kylegospo/bazzite/repo/fedora-%OS_VERSION%/kylegospo-bazzite-fedora-%OS_VERSION%.repo
   - https://copr.fedorainfracloud.org/coprs/ublue-os/staging/repo/fedora-%OS_VERSION%/ublue-os-staging-fedora-%OS_VERSION%.repo
 install:
+  - gamescope-session-plus
+  - gamescope-session-steam
   - scx-scheds


### PR DESCRIPTION
Testing the bare minimum for having `gamescope-session-steam/plus` installed and working. Not necessarily meant to be a seamless SteamOS-like experience like Bazzite