### PR TITLE
fix: zeliblue-deck updates

### DIFF
--- a/files/system_files/deck/usr/lib/systemd/system/ublue-update-force.service
+++ b/files/system_files/deck/usr/lib/systemd/system/ublue-update-force.service
@@ -4,7 +4,7 @@ Description=Force Universal Blue Update Oneshot Service
 [Service]
 Type=oneshot
 Environment="TOPGRADE_SKIP_BRKC_NOTIFY=true"
-ExecStart=/usr/bin/ublue-update --force
+ExecStart=/usr/bin/topgrade --config /usr/share/zeliblue/topgrade.toml
 RemainAfterExit=no
 Nice=19
 CPUSchedulingPolicy=batch

--- a/recipes/gnome/zeliblue-deck.yml
+++ b/recipes/gnome/zeliblue-deck.yml
@@ -124,7 +124,7 @@ modules:
     replace:
       - from-repo: https://copr.fedorainfracloud.org/coprs/kylegospo/bazzite/repo/fedora-%OS_VERSION%/kylegospo-bazzite-fedora-%OS_VERSION%.repo
         packages:
-          - ublue-update
+          # - ublue-update
           - upower
           - upower-libs
 


### PR DESCRIPTION
The idea here was to see if switching back from Bazzite's `ublue-update` fork back to upstream would fix an issue I've seen where the system updater always seems to falsely show an update is available, but it seems that might just be a `ublue-update` issue in general.

Still keeping these changes though because we don't need Bazzite's version for our needs, since I'm not supporting branch switching with zeliblue-deck.