### PR TITLE
refactor: Reorganize builds

### DIFF
--- a/.github/workflows/build-testing.yml
+++ b/.github/workflows/build-testing.yml
@@ -2,7 +2,7 @@ name: Zeliblue Testing
 on:
   schedule:
     - cron:
-        "00 06 * * *" # build at 06:00 UTC every day
+        "00 07 * * *" # build at 06:00 UTC every day
         # (20 minutes after last ublue images start building)
   push:
     branches:

--- a/.github/workflows/build-testing.yml
+++ b/.github/workflows/build-testing.yml
@@ -19,12 +19,12 @@ jobs:
     secrets: inherit
     with:
       recipe: gnome/zeliblue-testing.yml
-  build_bazzite:
-    name: Zeliblue Bazzite Testing
-    uses: ./.github/workflows/reusable-build.yml
-    secrets: inherit
-    with:
-      recipe: gnome/zeliblue-bazzite.yml
+  # build_bazzite:
+  #   name: Zeliblue Bazzite Testing
+  #   uses: ./.github/workflows/reusable-build.yml
+  #   secrets: inherit
+  #   with:
+  #     recipe: gnome/zeliblue-bazzite.yml
   build_cosmic:
     name: Zeliblue COSMIC Testing
     uses: ./.github/workflows/reusable-build.yml

--- a/files/scripts/plasma-packages-dnf5.sh
+++ b/files/scripts/plasma-packages-dnf5.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# Tell this script to exit if there are any errors.
+# You should have this in every custom script, to ensure that your completed
+# builds actually ran successfully without any errors!
+set -oue pipefail
+
+dnf5 -y remove \
+  ark \
+  ark-libs \
+  filelight \
+  kate \
+  kate-plugins \
+  kate-krunner-plugin \
+  kfind \
+  kwrite

--- a/recipes/common/common-base.yml
+++ b/recipes/common/common-base.yml
@@ -1,8 +1,17 @@
 modules:
+  - type: script
+    scripts:
+      - unwrap.sh
+
   - from-file: common/common-bling.yml
   - from-file: common/common-files.yml
   - from-file: common/common-flatpaks.yml
   - from-file: common/common-fonts.yml
-  - from-file: common/common-packages.yml
+
+  # - from-file: common/common-packages.yml
+  - type: script
+    scripts:
+      - common-packages-dnf5.sh
+
   - from-file: common/common-scripts.yml
   - from-file: common/common-modules.yml

--- a/recipes/cosmic/zeliblue-cosmic.yml
+++ b/recipes/cosmic/zeliblue-cosmic.yml
@@ -17,16 +17,7 @@ modules:
       - ARG ZELIBLUE_PRETTY_NAME="Zeliblue COSMIC"
       - ARG ZELIBLUE_IMAGE_TAG=testing
 
-  - from-file: common/common-bling.yml
-  - from-file: common/common-files.yml
-  - from-file: common/common-flatpaks.yml
-  - from-file: common/common-fonts.yml
-  - from-file: common/common-packages.yml
-  - from-file: common/common-scripts.yml
-  - from-file: common/common-modules.yml
-
-  - from-file: testing/testing-kernel.yml
-  - from-file: testing/testing-packages.yml
+  - from-file: common/common-base.yml
 
   - from-file: cosmic/cosmic-files.yml
   - from-file: cosmic/cosmic-flatpaks.yml

--- a/recipes/gnome/gnome-base.yml
+++ b/recipes/gnome/gnome-base.yml
@@ -1,4 +1,9 @@
 modules:
   - from-file: gnome/gnome-files.yml
-  - from-file: gnome/gnome-packages.yml
+
+  # - from-file: gnome/gnome-packages.yml
+  - type: script
+    scripts:
+      - gnome-packages-dnf5.sh
+
   - from-file: gnome/gnome-gschemas.yml

--- a/recipes/gnome/zeliblue-deck.yml
+++ b/recipes/gnome/zeliblue-deck.yml
@@ -6,8 +6,8 @@ alt-tags:
   - testing
 
 # the base image to build on top of (FROM) and the version tag to use
-base-image: ghcr.io/ublue-os/silverblue-main
-image-version: latest # latest is also supported if you want new updates ASAP
+base-image: ghcr.io/zelikos/zeliblue
+image-version: stable # latest is also supported if you want new updates ASAP
 
 # list of modules, executed in order
 # you can include multiple instances of the same module
@@ -17,31 +17,7 @@ modules:
       - ARG ZELIBLUE_PRETTY_NAME="Zeliblue Deck"
       - ARG ZELIBLUE_IMAGE_TAG=testing
 
-  - from-file: common/common-bling.yml
-  - from-file: common/common-files.yml
-  - from-file: common/common-flatpaks.yml
-  - from-file: common/common-fonts.yml
-
-  - type: script
-    scripts:
-      - common-packages-dnf5.sh
-
-  - from-file: common/common-scripts.yml
-  - from-file: common/common-modules.yml
-
-  - type: script
-    scripts:
-      - unwrap.sh
-
   - from-file: testing/testing-kernel.yml
-
-  - from-file: gnome/gnome-files.yml
-
-  - type: script
-    scripts:
-      - gnome-packages-dnf5.sh
-
-  - from-file: gnome/gnome-gschemas.yml
 
   - type: files
     files:
@@ -67,6 +43,10 @@ modules:
   - type: script
     scripts:
       - steamos-setup.sh
+
+  - type: script
+    scripts:
+      - image-info.sh
 
   - type: initramfs
     source: local

--- a/recipes/gnome/zeliblue-testing.yml
+++ b/recipes/gnome/zeliblue-testing.yml
@@ -17,25 +17,5 @@ modules:
       - ARG ZELIBLUE_PRETTY_NAME="Zeliblue"
       - ARG ZELIBLUE_IMAGE_TAG=testing
 
-  - from-file: common/common-bling.yml
-  - from-file: common/common-files.yml
-  - from-file: common/common-flatpaks.yml
-  - from-file: common/common-fonts.yml
-
-  - type: script
-    scripts:
-      - common-packages-dnf5.sh
-
-  - from-file: common/common-scripts.yml
-  - from-file: common/common-modules.yml
-
-  - from-file: testing/testing-kernel.yml
-  - from-file: testing/testing-packages.yml
-
-  - from-file: gnome/gnome-files.yml
-
-  - type: script
-    scripts:
-      - gnome-packages-dnf5.sh
-
-  - from-file: gnome/gnome-gschemas.yml
+  - from-file: common/common-base.yml
+  - from-file: gnome/gnome-base.yml

--- a/recipes/plasma/plasma-base.yml
+++ b/recipes/plasma/plasma-base.yml
@@ -1,4 +1,9 @@
 modules:
   - from-file: plasma/plasma-files.yml
-  - from-file: plasma/plasma-packages.yml
+
+  # - from-file: plasma/plasma-packages.yml
+  - type: script
+    scripts:
+      - plasma-packages-dnf5.sh
+
   - from-file: plasma/plasma-flatpaks.yml


### PR DESCRIPTION
- Moves the dnf5 switch to stable builds
- Rebases `zeliblue-deck` onto `zeliblue`

Deck builds will likely fail in this PR since stable won't have the dnf5 stuff until after this is merged