### PR TITLE
feat: Use CoreOS Stable kernel for stable tagged images

### DIFF
--- a/containerfiles/coreos-kernel/Containerfile
+++ b/containerfiles/coreos-kernel/Containerfile
@@ -1,5 +1,5 @@
 # Install CoreOS Stable kernel
-COPY --from=ghcr.io/ublue-os/akmods:coreos-stable-41 /tmp/rpms /tmp/coreos-kernel-rpms
+COPY --from=ghcr.io/ublue-os/akmods:coreos-stable-41 /kernel-rpms /tmp/coreos-kernel-rpms
 RUN --mount=type=cache,dst=/var/cache/libdnf5 \
     --mount=type=cache,dst=/var/cache/rpm-ostree \
     echo "Installing CoreOS Stable kernel" && \

--- a/containerfiles/coreos-kernel/Containerfile
+++ b/containerfiles/coreos-kernel/Containerfile
@@ -1,0 +1,25 @@
+# Install CoreOS Stable kernel
+COPY --from=ghcr.io/ublue-os/akmods:coreos-stable-41 /tmp/rpms /tmp/coreos-kernel-rpms
+RUN --mount=type=cache,dst=/var/cache/libdnf5 \
+    --mount=type=cache,dst=/var/cache/rpm-ostree \
+    echo "Installing CoreOS Stable kernel" && \
+
+    rpm --erase kernel --nodeps && \
+    rpm --erase kernel-core --nodeps && \
+    rpm --erase kernel-modules --nodeps && \
+    rpm --erase kernel-modules-core --nodeps && \
+    rpm --erase kernel-modules-extra --nodeps && \
+
+    dnf5 -y install \
+    /tmp/coreos-kernel-rpms/kernel-[0-9]*.rpm \
+    /tmp/coreos-kernel-rpms/kernel-core-*.rpm \
+    /tmp/coreos-kernel-rpms/kernel-modules-*.rpm \
+    /tmp/coreos-kernel-rpms/kernel-uki-virt-*.rpm
+
+# Install akmods
+# COPY --from=ghcr.io/ublue-os/akmods:coreos-stable-41 /rpms /tmp/akmods-rpms
+# RUN --mount=type=cache,dst=/var/cache/rpm-ostree \
+#     echo "Installing akmods" && \
+#     rpm-ostree install \
+#     /tmp/akmods-rpms/kmods/*ryzen-smu*.rpm \
+#     /tmp/akmods-rpms/kmods/*zenergy*.rpm

--- a/recipes/common/coreos-kernel.yml
+++ b/recipes/common/coreos-kernel.yml
@@ -1,0 +1,3 @@
+type: containerfile
+containerfiles:
+  - coreos-kernel

--- a/recipes/gnome/zeliblue.yml
+++ b/recipes/gnome/zeliblue.yml
@@ -22,3 +22,6 @@ modules:
   - from-file: common/coreos-kernel.yml
 
   - from-file: gnome/gnome-base.yml
+
+  - type: initramfs
+    source: local

--- a/recipes/gnome/zeliblue.yml
+++ b/recipes/gnome/zeliblue.yml
@@ -19,4 +19,6 @@ modules:
       - ARG ZELIBLUE_IMAGE_TAG=stable
 
   - from-file: common/common-base.yml
+  - from-file: common/coreos-kernel.yml
+
   - from-file: gnome/gnome-base.yml

--- a/recipes/plasma/zeliblue-kinoite.yml
+++ b/recipes/plasma/zeliblue-kinoite.yml
@@ -22,3 +22,6 @@ modules:
   - from-file: common/coreos-kernel.yml
 
   - from-file: plasma/plasma-base.yml
+
+  - type: initramfs
+    source: local

--- a/recipes/plasma/zeliblue-kinoite.yml
+++ b/recipes/plasma/zeliblue-kinoite.yml
@@ -19,4 +19,6 @@ modules:
       - ARG ZELIBLUE_IMAGE_TAG=stable
 
   - from-file: common/common-base.yml
+  - from-file: common/coreos-kernel.yml
+
   - from-file: plasma/plasma-base.yml


### PR DESCRIPTION
Swaps `stable` images over to the CoreOS Stable kernel rather than the latest kernel.