### PR TITLE
feat: Easier rebasing between stable and testing

### DIFF
--- a/files/system_files/deck/usr/libexec/os-branch-select
+++ b/files/system_files/deck/usr/libexec/os-branch-select
@@ -1,0 +1,63 @@
+#!/usr/bin/bash
+
+set -e
+
+if [[ $# -eq 1 ]]; then
+  case "$1" in
+    -c)
+      if [[ -f /var/ublue-update/branch ]]; then
+        branch=$(cat /var/ublue-update/branch)
+      else
+        branch=$(cut -d ":" -f4 <<< "$(rpm-ostree status --booted | grep -m 1 zeliblue)")
+      fi
+
+      # Trim and convert to lowercase
+      branch=$(echo "$branch" | tr '[:upper:]' '[:lower:]' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+      case $branch in
+        latest|stable)
+          echo rel
+          exit 0
+          ;;
+        testing)
+          echo rc
+          exit 0
+          ;;
+        # unstable)
+        #   echo main
+        #   exit 0
+        #   ;;
+        *)
+          # This can happen on CI builds or when downgrading from a newer build that knows of more branches.  The update
+          # path should decide how to handle it.
+          echo >&2 "Warning: Unrecognized currently selected branch name '$branch', updates may not succeed."
+          echo "$branch"
+          exit 0
+          ;;
+      esac
+      ;;
+    -l)
+      echo rel
+      echo rc
+      echo beta
+      # echo bc
+      # echo main
+      exit 0
+      ;;
+    rel|latest|stable)
+      /usr/bin/pkexec /usr/bin/zeliblue-update --rebase "stable"
+      exit 0
+      ;;
+    rc|beta|testing)
+      /usr/bin/pkexec /usr/bin/zeliblue-update --rebase "testing"
+      exit 0
+      ;;
+    # bc|main|unstable)
+    #   echo "The unstable branch has a high risk of breaking."
+    #   echo "Do NOT use it unless you know what you are doing."
+    #   /usr/bin/pkexec /usr/libexec/ublue-update-rebase "unstable"
+    #   exit 0
+    #   ;;
+  esac
+fi
+
+echo "Usage: steamos-select-branch <stable|testing>" 1>&2

--- a/files/system_files/shared/usr/bin/zeliblue-update
+++ b/files/system_files/shared/usr/bin/zeliblue-update
@@ -1,24 +1,28 @@
 #!/usr/bin/bash
 
-# TODO: Troubleshoot and re-enable later
-# function notify-send-system {
-#      if [[ ${LOGINCTL_VERSION} -ge 256 ]]; then
-#        user_name=$(loginctl list-users -j | jq -r '.[] | select(.state == "active") | .user')
-#        uid=$(loginctl list-users -j | jq -r '.[] | select(.state == "active") | .uid')
-#      else
-#        user_name=$(loginctl list-users --output=json | jq -r '.[] | select(.state == "active") | .user')
-#        uid=$(loginctl list-users --output=json | jq -r '.[] | select(.state == "active") | .uid')
-#      fi
-#      xdg_runtime_path="/run/user/$uid"
-#      sudo -u "$user_name" DBUS_SESSION_BUS_ADDRESS=unix:path="$xdg_runtime_path"/bus notify-send "Zeliblue Update" "$1" --app-name="Zeliblue Update" -u NORMAL
-# }
+source /etc/os-release
 
-# notify-send-system "Beginning full system update..."
+switch_image () {
+  rebase_to=$1
+  bootc switch --enforce-container-sigpolicy ghcr.io/zelikos/$rebase_to
+}
 
 if [[ $1 == "--check" ]]; then
   echo "Checking if update is available..."
   bootc update --check | grep "Update available"
   exit $?
+elif [[ $1 == "--rebase" ]]; then
+  branch=$2
+  case $branch in
+    stable|testing)
+      switch_image "$VARIANT_ID:$branch"
+      exit 0
+      ;;
+    *)
+      echo "Error: Branch $branch not recognized."
+      exit 1
+      ;;
+  esac
 else
   echo "Beginning full system update..."
 


### PR DESCRIPTION
Adds a `--rebase` option to zeliblue-update, and adds a `switch` just command for simpler rebasing between `stable` and `testing` branches.

Also, for zeliblue-deck, implements the `os-branch-select` script for Game Mode, leveraging the above change to zeliblue-update.