### PR TITLE
chore: Use dnf5 for kernel removal

### DIFF
--- a/containerfiles/bazzite-kernel/Containerfile
+++ b/containerfiles/bazzite-kernel/Containerfile
@@ -4,17 +4,12 @@ RUN --mount=type=cache,dst=/var/cache/libdnf5 \
     --mount=type=cache,dst=/var/cache/rpm-ostree \
     echo "Installing Bazzite kernel" && \
 
-    rpm --erase kernel --nodeps && \
-    rpm --erase kernel-core --nodeps && \
-    rpm --erase kernel-modules --nodeps && \
-    rpm --erase kernel-modules-core --nodeps && \
-    rpm --erase kernel-modules-extra --nodeps && \
+    dnf5 -y remove --no-autoremove kernel kernel-core kernel-modules kernel-modules-core kernel-modules-extra && \
 
     dnf5 -y install \
     /tmp/bazzite-kernel-rpms/kernel-[0-9]*.rpm \
     /tmp/bazzite-kernel-rpms/kernel-core-*.rpm \
-    /tmp/bazzite-kernel-rpms/kernel-modules-*.rpm \
-    /tmp/bazzite-kernel-rpms/kernel-uki-virt-*.rpm
+    /tmp/bazzite-kernel-rpms/kernel-modules-*.rpm
 
 # Install akmods
 # COPY --from=ghcr.io/ublue-os/akmods-extra:bazzite-41 /rpms /tmp/akmods-rpms

--- a/containerfiles/coreos-kernel/Containerfile
+++ b/containerfiles/coreos-kernel/Containerfile
@@ -1,20 +1,15 @@
 # Install CoreOS Stable kernel
-COPY --from=ghcr.io/ublue-os/akmods:coreos-stable-41 /kernel-rpms /tmp/coreos-kernel-rpms
+COPY --from=ghcr.io/ublue-os/akmods:coreos-stable-42 /kernel-rpms /tmp/coreos-kernel-rpms
 RUN --mount=type=cache,dst=/var/cache/libdnf5 \
     --mount=type=cache,dst=/var/cache/rpm-ostree \
     echo "Installing CoreOS Stable kernel" && \
 
-    rpm --erase kernel --nodeps && \
-    rpm --erase kernel-core --nodeps && \
-    rpm --erase kernel-modules --nodeps && \
-    rpm --erase kernel-modules-core --nodeps && \
-    rpm --erase kernel-modules-extra --nodeps && \
+    dnf5 -y remove --no-autoremove kernel kernel-core kernel-modules kernel-modules-core kernel-modules-extra && \
 
     dnf5 -y install \
     /tmp/coreos-kernel-rpms/kernel-[0-9]*.rpm \
     /tmp/coreos-kernel-rpms/kernel-core-*.rpm \
-    /tmp/coreos-kernel-rpms/kernel-modules-*.rpm \
-    /tmp/coreos-kernel-rpms/kernel-uki-virt-*.rpm
+    /tmp/coreos-kernel-rpms/kernel-modules-*.rpm
 
 # Install akmods
 # COPY --from=ghcr.io/ublue-os/akmods:coreos-stable-41 /rpms /tmp/akmods-rpms


### PR DESCRIPTION
Also bumps the coreos kernel to uBlue's `coreos-stable-42`, and omits installing `kernel-uki-virt-*` as it seems to no longer be needed.