### PR TITLE
ci(ISOs): Switch to `container-storage-action`

### DIFF
--- a/.github/workflows/reusable-build-live-iso.yml
+++ b/.github/workflows/reusable-build-live-iso.yml
@@ -45,6 +45,12 @@ jobs:
           sudo apt install -y \
             podman
 
+      - name: Maximize build space
+        if: matrix.platform != 'arm64' && env.IMAGE_NAME == 'zeliblue-deck'
+        uses: ublue-os/remove-unwanted-software@cc0becac701cf642c8f0a6613bbdaf5dc36b259e # v9
+        with:
+          remove-codeql: true
+
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 


### PR DESCRIPTION
This will reduce build times by ~3 minutes, and I'm already using it in the regular image builds.

Deck ISOs are currently too large for this change to work, so we'll conditionally enable the "Maximize build space" action for them.