### PR TITLE
feat(testing): Fedora 44 update

### DIFF
--- a/.github/workflows/build-testing.yml
+++ b/.github/workflows/build-testing.yml
@@ -27,7 +27,7 @@ jobs:
       image: zeliblue
       stream_name: testing
       kernel: main
-      os_version: "43"
+      os_version: "44"
   # build_deck_testing:
   #   name: Zeliblue Deck Testing
   #   uses: ./.github/workflows/reusable-build-image.yml

--- a/build_files/base/03-base-overrides.sh
+++ b/build_files/base/03-base-overrides.sh
@@ -21,7 +21,7 @@ OVERRIDES=(
     "mesa-vulkan-drivers"
 )
 
-dnf5 distro-sync -y --repo='fedora-multimedia' "${OVERRIDES[@]}"
+dnf5 distro-sync --skip-unavailable -y --repo='fedora-multimedia' "${OVERRIDES[@]}"
 
 # Replace podman provided policy.json with ublue-os one.
 mv /usr/etc/containers/policy.json /etc/containers/policy.json

--- a/build_files/shared/01-install-kernel.sh
+++ b/build_files/shared/01-install-kernel.sh
@@ -41,9 +41,9 @@ mv -f 50-dracut.install.bak 50-dracut.install
 popd
 
 # Install akmods
-dnf5 -y copr enable ublue-os/akmods
+# dnf5 -y copr enable ublue-os/akmods
 
-dnf5 -y install /tmp/akmods/kmods/*framework-laptop*.rpm
+# dnf5 -y install /tmp/akmods/kmods/*framework-laptop*.rpm
 
 if [[ $AKMODS_FLAVOR == "bazzite" ]]; then
   # Fetch Extra AKMODS
@@ -57,4 +57,4 @@ if [[ $AKMODS_FLAVOR == "bazzite" ]]; then
       /tmp/akmods-extra/kmods/*ryzen-smu*.rpm
 fi
 
-dnf5 -y copr remove ublue-os/akmods
+# dnf5 -y copr remove ublue-os/akmods


### PR DESCRIPTION
Bump testing image to Fedora 44 and applies some fixes/workarounds needed as a result of doing so.

Notably also disables akmods (again), since attempting to install the framework kmod was causing a build error due to it being missing; I'm not gonna bother investigating a solution since the only noticeable benefit of having the kmod (if not yet upstreamed) is having keyboard backlight control in the OS, which I can instead just do through Fn keys. So, no big loss to not have it.